### PR TITLE
internal/cli: always use :latest sandbox image tag

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,21 +16,18 @@ import (
 )
 
 // Version is set at build time via -ldflags (e.g. -X cli.Version=1.2.3).
-// When empty (dev build), the binary pulls the :latest sandbox image and
-// the doctor subcommand displays "dev" as the version string.
+// Displayed by the doctor subcommand; does not affect sandbox image selection.
 var Version = ""
 
 // sandboxImageBase is the registry path for the published sandbox image.
 const sandboxImageBase = "ghcr.io/latere-ai/sandbox-claude"
 
 // defaultSandboxImage returns the tagged sandbox image reference.
-// Release builds (version set via ldflags) use the matching version tag.
-// Dev builds query the GitHub API for the latest release of latere-ai/images
-// and use that tag. Falls back to :latest only if the query fails.
+// Queries the GitHub API for the latest release tag of latere-ai/images and
+// uses that tag. Falls back to :latest only if the query fails. The wallfacer
+// version is intentionally not used — sandbox images have an independent
+// release cycle.
 func defaultSandboxImage() string {
-	if Version != "" {
-		return sandboxImageBase + ":v" + Version
-	}
 	if tag := resolveLatestImageTag(); tag != "" {
 		logger.Main.Info("resolved latest sandbox image tag", "tag", tag)
 		return sandboxImageBase + ":" + tag
@@ -39,7 +36,7 @@ func defaultSandboxImage() string {
 }
 
 // resolveLatestImageTag queries the GitHub API for the latest release tag
-// of the latere-ai/images repository. Returns the tag name (e.g. "v0.0.3")
+// of the latere-ai/images repository. Returns the tag name (e.g. "v0.0.4")
 // or empty string on failure.
 func resolveLatestImageTag() string {
 	client := &http.Client{Timeout: 5 * time.Second}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -146,8 +146,8 @@ func RunDoctor(configDir string) {
 		}
 
 		codexTag := ":latest"
-		if Version != "" {
-			codexTag = ":v" + Version
+		if tag := resolveLatestImageTag(); tag != "" {
+			codexTag = ":" + tag
 		}
 		codexImage := envOrDefault("CODEX_SANDBOX_IMAGE", "ghcr.io/latere-ai/sandbox-codex"+codexTag)
 		if imageExists(runtimePath, codexImage) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -281,9 +281,11 @@ func TestRunDoctor_SandboxImageFallback(t *testing.T) {
 	}
 }
 
-// TestRunDoctor_VersionTaggedCodex verifies that when Version is set, the
-// codex sandbox image uses the version tag.
-func TestRunDoctor_VersionTaggedCodex(t *testing.T) {
+// TestRunDoctor_CodexImageNotCached verifies that doctor reports the codex
+// sandbox image as not cached when the runtime does not have it locally.
+// The codex image tag is resolved from the latest latere-ai/images release
+// (independent of the wallfacer Version).
+func TestRunDoctor_CodexImageNotCached(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses shell scripts")
 	}
@@ -309,7 +311,6 @@ func TestRunDoctor_VersionTaggedCodex(t *testing.T) {
 		RunDoctor(configDir)
 	})
 
-	// Should use version tag for codex image check.
 	if !strings.Contains(out, "Codex sandbox image not cached") {
 		t.Errorf("expected codex image not cached message, got:\n%s", out)
 	}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -196,40 +196,40 @@ func TestOpenBrowser_InvokesPlatformCommand(t *testing.T) {
 	}
 }
 
-// TestDefaultSandboxImage_WithVersion verifies that when Version is set the
-// image reference includes the version tag instead of :latest.
+// TestDefaultSandboxImage_WithVersion verifies that even when Version is set,
+// the image tag is resolved from latere-ai/images (not the wallfacer version),
+// because the two repos have an independent release cycle.
 func TestDefaultSandboxImage_WithVersion(t *testing.T) {
 	old := Version
 	Version = "1.2.3"
 	defer func() { Version = old }()
 
 	got := defaultSandboxImage()
-	if got != sandboxImageBase+":v1.2.3" {
-		t.Fatalf("expected image tag :v1.2.3, got %q", got)
+	// Must never use the embedded wallfacer version as the image tag.
+	if got == sandboxImageBase+":v1.2.3" {
+		t.Fatalf("must not use embedded wallfacer version as image tag, got %q", got)
+	}
+	if !strings.HasPrefix(got, sandboxImageBase+":") {
+		t.Fatalf("unexpected image base, got %q", got)
 	}
 }
 
-// TestDefaultSandboxImage_DevBuild verifies that the dev build (empty Version)
-// either resolves to the latest release tag or falls back to :latest.
+// TestDefaultSandboxImage_DevBuild verifies that a dev build (empty Version)
+// resolves to the latest release tag or falls back to :latest.
 func TestDefaultSandboxImage_DevBuild(t *testing.T) {
 	old := Version
 	Version = ""
 	defer func() { Version = old }()
 
 	got := defaultSandboxImage()
-	// Dev build queries GitHub API for the latest tag; if the query succeeds
-	// we get e.g. ":v0.0.4", otherwise ":latest" as fallback.
-	if got == sandboxImageBase+":latest" {
-		return // fallback path — OK
-	}
+	// Either the GitHub-resolved tag (e.g. ":v0.0.4") or the :latest fallback.
 	if !strings.HasPrefix(got, sandboxImageBase+":") {
 		t.Fatalf("unexpected image base, got %q", got)
 	}
 	tag := strings.TrimPrefix(got, sandboxImageBase+":")
-	if tag == "" || tag == "latest" {
-		t.Fatalf("expected a resolved tag or :latest, got %q", got)
+	if tag == "" {
+		t.Fatalf("expected a non-empty tag, got %q", got)
 	}
-	// Resolved a real tag (e.g. "v0.0.4") — valid.
 }
 
 func TestCodexImageFromClaude(t *testing.T) {


### PR DESCRIPTION
## Summary

- Release builds embedded the wallfacer version (e.g. `v0.0.7-alpha.1`) as the sandbox image tag, but `latere-ai/images` has an independent release cycle — no image exists for wallfacer pre-release versions → container launch fails with _Unable to find image locally_
- Both dev and release builds now query `https://api.github.com/repos/latere-ai/images/releases/latest` for the actual latest sandbox image tag (e.g. `v0.0.4`) and use that
- Falls back to `:latest` only when the API call fails (offline / rate-limited)

## Changes

- `internal/cli/cli.go`: `defaultSandboxImage()` always calls `resolveLatestImageTag()` — the `if Version != "" { return ":v" + Version }` early-exit is removed
- `internal/cli/doctor.go`: Codex image tag also resolved via `resolveLatestImageTag()` instead of `:v<Version>`
- Tests updated: assert the returned tag is never the embedded wallfacer version; accept any resolved tag or `:latest` fallback

## Test plan

- [ ] `make test-backend` passes
- [ ] Build with `VERSION=0.0.7-alpha.1`; verify logged image tag is e.g. `ghcr.io/latere-ai/sandbox-claude:v0.0.4`, not `v0.0.7-alpha.1`
- [ ] Disconnect from network; verify startup falls back to `ghcr.io/latere-ai/sandbox-claude:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)