### PR TITLE
all: switch wallfacer to the unified sandbox-agents image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,7 +457,7 @@ make e2e-dependency-dag WORKSPACE="$WORKSPACE"
 - After changes to `internal/runner/` (task execution, commit pipeline, conflict resolution)
 - After changes to `internal/handler/tasks*.go` or `internal/handler/execute.go` (task API, automation)
 - After changes to `internal/gitutil/` (worktree, rebase, merge operations)
-- After sandbox image updates (new versions of sandbox-claude or sandbox-codex)
+- After sandbox image updates (new versions of sandbox-agents)
 - Before releases to verify end-to-end correctness
 
 ## Bug fixes require a reproducible test

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ SANDBOX_TAG      := $(shell \
 ifeq ($(SANDBOX_TAG),)
 $(error Could not resolve the latest sandbox image tag from GitHub. Check your network, or override: make SANDBOX_TAG=vX.Y.Z <target>)
 endif
-IMAGE            := sandbox-claude:$(SANDBOX_TAG)
-GHCR_IMAGE       := ghcr.io/latere-ai/sandbox-claude:$(SANDBOX_TAG)
-CODEX_IMAGE      := sandbox-codex:$(SANDBOX_TAG)
-GHCR_CODEX_IMAGE := ghcr.io/latere-ai/sandbox-codex:$(SANDBOX_TAG)
+# Single unified sandbox image. Both Claude Code and Codex live in
+# sandbox-agents; the entrypoint dispatches via WALLFACER_AGENT.
+IMAGE            := sandbox-agents:$(SANDBOX_TAG)
+GHCR_IMAGE       := ghcr.io/latere-ai/sandbox-agents:$(SANDBOX_TAG)
 NAME             := wallfacer
 
 # Load .env if it exists
@@ -67,13 +67,11 @@ build-desktop-windows:
 build-desktop-linux:
 	go tool wails build -tags desktop -skipbindings -s -platform linux/amd64
 
-# Pull sandbox images from GHCR and tag locally.
-# Images are maintained in https://github.com/latere-ai/images
+# Pull the unified sandbox image from GHCR and tag locally.
+# Image source: https://github.com/latere-ai/images
 pull-images:
 	$(PODMAN) pull $(GHCR_IMAGE)
 	$(PODMAN) tag $(GHCR_IMAGE) $(IMAGE)
-	$(PODMAN) pull $(GHCR_CODEX_IMAGE)
-	$(PODMAN) tag $(GHCR_CODEX_IMAGE) $(CODEX_IMAGE)
 
 # Build and run the Go server natively
 server:
@@ -87,7 +85,7 @@ VOLUME_MOUNTS := $(foreach ws,$(WORKSPACES),-v $(ws):/workspace/$(notdir $(ws)):
 
 # Headless one-shot: make run PROMPT="fix the failing tests"
 # Mount host gitconfig read-only; set safe.directory via env so the file stays immutable
-GITCONFIG_MOUNT := -v $(HOME)/.gitconfig:/home/claude/.gitconfig:ro,z \
+GITCONFIG_MOUNT := -v $(HOME)/.gitconfig:/home/agent/.gitconfig:ro,z \
 	-e "GIT_CONFIG_COUNT=1" \
 	-e "GIT_CONFIG_KEY_0=safe.directory" \
 	-e "GIT_CONFIG_VALUE_0=*"
@@ -101,7 +99,7 @@ endif
 		--env-file .env \
 		$(GITCONFIG_MOUNT) \
 		$(VOLUME_MOUNTS) \
-		-v claude-config:/home/claude/.claude \
+		-v claude-config:/home/agent/.claude \
 		-w /workspace \
 		$(IMAGE) -p "$(PROMPT)" --verbose --output-format stream-json
 
@@ -112,7 +110,7 @@ shell:
 		--env-file .env \
 		$(GITCONFIG_MOUNT) \
 		$(VOLUME_MOUNTS) \
-		-v claude-config:/home/claude/.claude \
+		-v claude-config:/home/agent/.claude \
 		-w /workspace \
 		--entrypoint /bin/bash \
 		$(IMAGE)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -116,10 +116,10 @@ See [Exploring Ideas](exploring-ideas.md) for the full planning chat guide.
 
 **Global Sandbox Routing** -- Select the default sandbox type and override the sandbox for individual activities: Implementation, Testing, Refinement, Title generation, Oversight summary, Commit message, and Idea agent. Each dropdown offers the available sandbox types (claude, codex) or "default".
 
-Wallfacer supports two sandbox types:
+Wallfacer supports two sandbox types, both backed by the same unified container image (`sandbox-agents:latest`). The container's entrypoint dispatches to the right CLI based on the `WALLFACER_AGENT` env var the runner sets per task:
 
-- **Claude** -- runs Claude Code CLI inside an Ubuntu-based container (`sandbox-claude:latest`). Requires either `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
-- **Codex** -- runs OpenAI Codex CLI inside a companion image (`sandbox-codex:latest`). Requires `OPENAI_API_KEY` or host `~/.codex/auth.json`.
+- **Claude** -- runs Claude Code CLI (`WALLFACER_AGENT=claude`). Requires either `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
+- **Codex** -- runs OpenAI Codex CLI (`WALLFACER_AGENT=codex`). Requires `OPENAI_API_KEY` or host `~/.codex/auth.json`.
 
 Each task can be assigned a specific sandbox type when created or edited. The task-level sandbox selection overrides the global default for that task's implementation run.
 
@@ -328,7 +328,7 @@ wallfacer run [flags] [workspace...]
 | `-addr` | `ADDR` | `:8080` | Listen address |
 | `-data` | `DATA_DIR` | `~/.wallfacer/data` | Task data directory |
 | `-container` | `CONTAINER_CMD` | auto-detected | Container runtime command (`podman` or `docker`) |
-| `-image` | `SANDBOX_IMAGE` | `ghcr.io/latere-ai/sandbox-claude:latest` | Sandbox image name |
+| `-image` | `SANDBOX_IMAGE` | `ghcr.io/latere-ai/sandbox-agents:latest` | Sandbox image name (same image serves both Claude and Codex; `WALLFACER_AGENT` selects the CLI) |
 | `-env-file` | `ENV_FILE` | `~/.wallfacer/.env` | Env file passed to containers |
 | `-no-browser` | -- | `false` | Skip auto-opening the browser |
 | `-log-format` | `LOG_FORMAT` | `text` | Log output format: `text` or `json` |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,7 +28,7 @@ On startup, Wallfacer restores the most recently used workspace group from your 
 
 On first run, Wallfacer auto-creates `~/.wallfacer/` and a template `.env` file. The browser opens automatically to `http://localhost:8080` showing a task board with four columns.
 
-The sandbox image (`ghcr.io/latere-ai/sandbox-claude:latest`) is pulled automatically the first time a task runs. This is a one-time download (~1 GB). To build sandbox images locally instead, see [Building sandbox images from source](#building-sandbox-images-from-source) below.
+The sandbox image (`ghcr.io/latere-ai/sandbox-agents:latest`) is pulled automatically the first time a task runs. This is a one-time download (~1 GB). The same image hosts both Claude Code and Codex; the runner sets `WALLFACER_AGENT` per task to pick the right CLI. To build the sandbox image locally instead, see [Building the sandbox image from source](#building-the-sandbox-image-from-source) below.
 
 ## Step 3 — Configure Your Credential
 
@@ -128,18 +128,18 @@ Windows users can also run Wallfacer inside WSL2 with the same experience as nat
 
 The container runtime override `CONTAINER_CMD` works on all platforms if the auto-detection picks the wrong binary.
 
-## Building Sandbox Images from Source
+## Building the Sandbox Image from Source
 
-Sandbox images are pulled automatically from `ghcr.io/latere-ai/`. If you need to customize them or build offline, clone the images repository and build locally:
+The sandbox image is pulled automatically from `ghcr.io/latere-ai/`. If you need to customize it or build offline, clone the images repository and build locally:
 
 ```bash
 git clone https://github.com/latere-ai/images.git
 cd images
-make                   # Build both sandbox-claude and sandbox-codex
+make                   # Build the unified sandbox-agents image
 make RUNTIME=docker    # Use Docker instead of Podman
 ```
 
-The local build tags the images as `sandbox-claude:latest` and `sandbox-codex:latest`, which Wallfacer finds automatically. See the [images repository](https://github.com/latere-ai/images) for details on what's bundled and the entrypoint contract.
+The local build tags the image as `sandbox-agents:latest`, which Wallfacer finds automatically. See the [images repository](https://github.com/latere-ai/images) for details on what's bundled, the `WALLFACER_AGENT` dispatch contract, and the JSON-envelope output expected by the runner.
 
 ## Next Steps
 

--- a/docs/internals/api-and-transport.md
+++ b/docs/internals/api-and-transport.md
@@ -355,8 +355,8 @@ The `containerJSON` struct uses `json.RawMessage` for `Names` and `any` for `Cre
 `ensureImage()` in `server.go` runs at startup:
 
 1. **Check local**: `<runtime> images -q <image>` — if output is non-empty, the image exists locally and is used as-is.
-2. **Pull from registry**: `<runtime> pull <image>` — streams stdout/stderr to the terminal. The default image is `ghcr.io/latere-ai/sandbox-claude:latest`.
-3. **Fallback to local**: If the pull fails and the requested image differs from `sandbox-claude:latest`, check whether `sandbox-claude:latest` exists locally. If so, use it instead.
+2. **Pull from registry**: `<runtime> pull <image>` — streams stdout/stderr to the terminal. The default image is `ghcr.io/latere-ai/sandbox-agents:latest`.
+3. **Fallback to local**: If the pull fails and the requested image differs from `sandbox-agents:latest`, check whether `sandbox-agents:latest` exists locally. If so, use it instead.
 4. **No image**: If neither the remote nor local fallback is available, the server starts anyway but warns that tasks may fail.
 
 ### Container Labels

--- a/docs/internals/development.md
+++ b/docs/internals/development.md
@@ -26,7 +26,7 @@ Pull sandbox images (optional — auto-pulled from ghcr.io at runtime):
 make pull-images    # Pull Claude and Codex sandbox images
 ```
 
-`make build` builds the binary and pulls both sandbox images in one step. Sandbox images are maintained in a separate repository (`github.com/latere-ai/images`); for normal development the server pulls `ghcr.io/latere-ai/sandbox-claude:latest` automatically on first task run.
+`make build` builds the binary and pulls the unified sandbox image in one step. The sandbox image is maintained in a separate repository (`github.com/latere-ai/images`); for normal development the server pulls `ghcr.io/latere-ai/sandbox-agents:latest` automatically on first task run. The same image ships both the Claude Code and Codex CLIs; the entrypoint dispatches to the correct one based on `WALLFACER_AGENT` (`claude` or `codex`), which the runner sets per task.
 
 ## Configure Credentials
 
@@ -71,21 +71,21 @@ make test-frontend  # Frontend JS tests: cd ui && npx vitest@2 run
 ## Sandbox Images
 
 ```bash
-podman images sandbox-claude   # or: docker images sandbox-claude
+podman images sandbox-agents   # or: docker images sandbox-agents
 ```
 
-The sandbox images are maintained in a separate repository ([github.com/latere-ai/images](https://github.com/latere-ai/images)). They are Ubuntu 24.04 images bundling Go 1.25, Node.js 22, Python 3, and the respective agent CLI (Claude Code or Codex). Multi-arch images (amd64 + arm64) are published to `ghcr.io/latere-ai/sandbox-claude` and `ghcr.io/latere-ai/sandbox-codex` on version tags via GitHub Actions.
+The sandbox image is maintained in a separate repository ([github.com/latere-ai/images](https://github.com/latere-ai/images)). It is an Ubuntu 24.04 image bundling Go 1.25, Node.js 22, Python 3, and both agent CLIs (Claude Code and Codex). The entrypoint dispatches to the requested CLI based on `WALLFACER_AGENT`. The multi-arch image (amd64 + arm64) is published to `ghcr.io/latere-ai/sandbox-agents` on version tags via GitHub Actions.
 
 To build sandbox images locally (e.g. for customization or offline use):
 
 ```bash
 git clone https://github.com/latere-ai/images.git
 cd images
-make                   # Build both sandbox-claude and sandbox-codex
+make                   # Build the unified sandbox-agents image
 make RUNTIME=docker    # Use Docker instead of Podman
 ```
 
-Local builds are tagged as `sandbox-claude:latest` and `sandbox-codex:latest`, which wallfacer picks up automatically as the fallback when the GHCR image is unavailable.
+Local builds are tagged as `sandbox-agents:latest`, which wallfacer picks up automatically as the fallback when the GHCR image is unavailable.
 
 ## Release Workflow
 
@@ -96,7 +96,7 @@ Releases are triggered by pushing a version tag (`v*`). Two GitHub Actions workf
 | `release-binary.yml` | `wallfacer-{linux,darwin,windows}-{amd64,arm64}` binaries on the GitHub Release |
 | `release-desktop.yml` | Signed desktop apps (`Wallfacer-Desktop-*`) on the GitHub Release |
 
-Sandbox images (`ghcr.io/latere-ai/sandbox-claude` and `ghcr.io/latere-ai/sandbox-codex`) are built and published from [`github.com/latere-ai/images`](https://github.com/latere-ai/images) on its own release cadence.
+The unified sandbox image (`ghcr.io/latere-ai/sandbox-agents`) is built and published from [`github.com/latere-ai/images`](https://github.com/latere-ai/images) on its own release cadence.
 
 **Version embedding.** Release binaries are built with `-ldflags "-X changkun.de/x/wallfacer/internal/cli.Version=X.Y.Z"`. This stamps the wallfacer version for `wallfacer doctor` and usage output. It does **not** determine the sandbox image tag.
 

--- a/docs/internals/git-worktrees.md
+++ b/docs/internals/git-worktrees.md
@@ -63,7 +63,7 @@ The sandbox container sees worktrees, not the live main working directory:
 ```
 ~/.wallfacer/worktrees/<uuid>/<repo>  ->  /workspace/<repo>:z   (read-write)
 AGENTS.md (or CLAUDE.md)               ->  /workspace/AGENTS.md  (read-only)
-claude-config (named volume)           ->  /home/claude/.claude
+claude-config (named volume)           ->  /home/agent/.claude
 ```
 
 The `.env` file is passed via `--env-file`, not as a bind mount.

--- a/docs/internals/workspaces-and-config.md
+++ b/docs/internals/workspaces-and-config.md
@@ -132,8 +132,10 @@ This is handled by `appendInstructionsMount()` in `container.go`, which selects 
 
 The `internal/sandbox` package defines two sandbox types as `Type` constants:
 
-- **`Claude`** (`"claude"`) — Runs Claude Code in a container built from the `sandbox-claude` image. Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
-- **`Codex`** (`"codex"`) — Runs OpenAI Codex CLI in a container built from the `sandbox-codex` image. Authenticates via `OPENAI_API_KEY` or host `~/.codex/auth.json`.
+- **`Claude`** (`"claude"`) — Runs Claude Code in a `sandbox-agents` container with `WALLFACER_AGENT=claude`. Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
+- **`Codex`** (`"codex"`) — Runs OpenAI Codex CLI in the same `sandbox-agents` container with `WALLFACER_AGENT=codex`. Authenticates via `OPENAI_API_KEY` or host `~/.codex/auth.json`.
+
+Both sandbox types use the same unified container image — only the `WALLFACER_AGENT` env var differs at runtime.
 
 `sandbox.Default(value)` returns the parsed type or falls back to `Claude` for unknown values.
 
@@ -161,12 +163,9 @@ The seven routable activities (defined as `SandboxActivity` constants in `intern
 
 Two additional activities (`test`, `oversight-test`) are usage-attribution-only and not used for sandbox routing.
 
-### 🖼️ Container image selection
+### 🖼️ Container image
 
-`Runner.sandboxImageForSandbox()` selects the container image:
-
-- For **Claude**: uses the configured `--image` flag value (default: `ghcr.io/latere-ai/sandbox-claude:latest`).
-- For **Codex**: derives the image by replacing `sandbox-claude` with `sandbox-codex` in the image name, preserving the registry prefix and tag/digest. Falls back to `sandbox-codex:latest` if the base image is empty.
+The runner uses the configured `--image` flag value verbatim for every task and sub-agent — there is no per-sandbox image rewriting. The default is `ghcr.io/latere-ai/sandbox-agents:latest`, the unified image that ships both Claude Code and Codex. The agent CLI is selected at container start by the `WALLFACER_AGENT` env var the runner injects (`claude` or `codex`).
 
 ### 🧠 Model selection
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -28,7 +28,9 @@ var Version = ""
 var SandboxTag = ""
 
 // sandboxImageBase is the registry path for the published sandbox image.
-const sandboxImageBase = "ghcr.io/latere-ai/sandbox-claude"
+// The single sandbox-agents image ships both Claude Code and Codex CLIs;
+// the entrypoint selects between them at runtime via WALLFACER_AGENT.
+const sandboxImageBase = "ghcr.io/latere-ai/sandbox-agents"
 
 // defaultSandboxImage returns the tagged sandbox image reference.
 // Builds that embed SandboxTag via ldflags use that tag directly.
@@ -71,41 +73,7 @@ func resolveLatestImageTag() string {
 // fallbackSandboxImage is the locally-built image name used when the
 // remote registry image cannot be pulled (e.g. no network, auth failure).
 // This intentionally uses :latest as a last-resort local fallback.
-const fallbackSandboxImage = "sandbox-claude:latest"
-
-// codexImageFromClaude derives the codex sandbox image name from the claude
-// base image by replacing "sandbox-claude" with "sandbox-codex" in the
-// repository name, preserving registry prefix, tag, and digest.
-func codexImageFromClaude(baseImage string) string {
-	baseImage = strings.TrimSpace(baseImage)
-	if baseImage == "" {
-		return "sandbox-codex:latest"
-	}
-	if strings.Contains(strings.ToLower(baseImage), "sandbox-codex") {
-		return baseImage
-	}
-	registry := baseImage
-	digest := ""
-	if at := strings.Index(registry, "@"); at != -1 {
-		digest = registry[at:]
-		registry = registry[:at]
-	}
-	tag := ""
-	if at := strings.LastIndex(registry, ":"); at != -1 {
-		tag = registry[at:]
-		registry = registry[:at]
-	}
-	prefix := ""
-	repoName := registry
-	if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-		prefix = repoName[:idx+1]
-		repoName = repoName[idx+1:]
-	}
-	if repoName != "sandbox-claude" {
-		return baseImage
-	}
-	return prefix + "sandbox-codex" + tag + digest
-}
+const fallbackSandboxImage = "sandbox-agents:latest"
 
 // ConfigDir returns the default wallfacer configuration directory.
 func ConfigDir() string {
@@ -161,7 +129,7 @@ func initConfigDir(configDir, envFile string) {
 			"# Optional: model for auto-generating task titles (falls back to default model).\n" +
 			"# CLAUDE_TITLE_MODEL=\n\n" +
 			"# =============================================================================\n" +
-			"# OpenAI Codex sandbox (use with wallfacer-codex image)\n" +
+			"# OpenAI Codex sandbox (uses the unified sandbox-agents image; WALLFACER_AGENT=codex selects this CLI at runtime)\n" +
 			"# =============================================================================\n\n" +
 			"# Authentication: set your OpenAI API key.\n" +
 			"# OPENAI_API_KEY=sk-...\n\n" +

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -133,27 +133,19 @@ func RunDoctor(configDir string) {
 	}
 	fmt.Printf("[ok] Sandbox backend: %s\n", sandboxBackend)
 
-	// --- Sandbox images ---
+	// --- Sandbox image ---
+	// The unified sandbox-agents image ships both Claude Code and Codex;
+	// the entrypoint dispatches via WALLFACER_AGENT. A single image check
+	// covers both agent types.
 	if lookErr == nil {
 		image := envOrDefault("SANDBOX_IMAGE", defaultSandboxImage())
 		switch {
 		case imageExists(runtimePath, image):
-			fmt.Printf("[ok] Claude sandbox image: %s\n", image)
+			fmt.Printf("[ok] Sandbox image: %s\n", image)
 		case image != fallbackSandboxImage && imageExists(runtimePath, fallbackSandboxImage):
-			fmt.Printf("[ ] Claude sandbox image %s not cached (fallback %s available)\n", image, fallbackSandboxImage)
+			fmt.Printf("[ ] Sandbox image %s not cached (fallback %s available)\n", image, fallbackSandboxImage)
 		default:
-			fmt.Printf("[ ] Claude sandbox image not cached (will be pulled on first task)\n")
-		}
-
-		codexTag := ":latest"
-		if Version != "" {
-			codexTag = ":v" + Version
-		}
-		codexImage := envOrDefault("CODEX_SANDBOX_IMAGE", "ghcr.io/latere-ai/sandbox-codex"+codexTag)
-		if imageExists(runtimePath, codexImage) {
-			fmt.Printf("[ok] Codex sandbox image: %s\n", codexImage)
-		} else {
-			fmt.Printf("[ ] Codex sandbox image not cached (pulled on demand if Codex is used)\n")
+			fmt.Printf("[ ] Sandbox image not cached (will be pulled on first task)\n")
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -258,10 +258,10 @@ func TestRunDoctor_SandboxImageFallback(t *testing.T) {
 	}
 
 	fakeRuntime := filepath.Join(t.TempDir(), "podman")
-	// Responds with version, returns found only for sandbox-claude:latest (the fallback).
+	// Responds with version, returns found only for sandbox-agents:latest (the fallback).
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"version\" ]; then echo \"5.0.0\"; exit 0; fi\n" +
-		"if [ \"$1\" = \"images\" ] && [ \"$3\" = \"sandbox-claude:latest\" ]; then echo \"abc123\"; exit 0; fi\n" +
+		"if [ \"$1\" = \"images\" ] && [ \"$3\" = \"sandbox-agents:latest\" ]; then echo \"abc123\"; exit 0; fi\n" +
 		"if [ \"$1\" = \"images\" ]; then echo \"\"; exit 0; fi\n" +
 		"exit 0\n"
 	if err := os.WriteFile(fakeRuntime, []byte(script), 0755); err != nil {
@@ -270,7 +270,7 @@ func TestRunDoctor_SandboxImageFallback(t *testing.T) {
 
 	t.Setenv("CONTAINER_CMD", fakeRuntime)
 	// Use a non-fallback image so the fallback path triggers.
-	t.Setenv("SANDBOX_IMAGE", "ghcr.io/latere-ai/sandbox-claude:v99")
+	t.Setenv("SANDBOX_IMAGE", "ghcr.io/latere-ai/sandbox-agents:v99")
 
 	out := captureStdout(func() {
 		RunDoctor(configDir)
@@ -278,40 +278,6 @@ func TestRunDoctor_SandboxImageFallback(t *testing.T) {
 
 	if !strings.Contains(out, "not cached (fallback") {
 		t.Errorf("expected fallback image message, got:\n%s", out)
-	}
-}
-
-// TestRunDoctor_VersionTaggedCodex verifies that when Version is set, the
-// codex sandbox image uses the version tag.
-func TestRunDoctor_VersionTaggedCodex(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses shell scripts")
-	}
-	old := Version
-	Version = "1.0.0"
-	defer func() { Version = old }()
-
-	configDir := t.TempDir()
-	envFile := filepath.Join(configDir, ".env")
-	if err := os.WriteFile(envFile, []byte("ANTHROPIC_API_KEY=sk-ant-test\n"), 0600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	fakeRuntime := filepath.Join(t.TempDir(), "podman")
-	script := "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then echo \"5.0.0\"; exit 0; fi\nif [ \"$1\" = \"images\" ]; then echo \"\"; exit 0; fi\nexit 0\n"
-	if err := os.WriteFile(fakeRuntime, []byte(script), 0755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	t.Setenv("CONTAINER_CMD", fakeRuntime)
-
-	out := captureStdout(func() {
-		RunDoctor(configDir)
-	})
-
-	// Should use version tag for codex image check.
-	if !strings.Contains(out, "Codex sandbox image not cached") {
-		t.Errorf("expected codex image not cached message, got:\n%s", out)
 	}
 }
 
@@ -339,7 +305,7 @@ func TestRunDoctor_SandboxImageCached(t *testing.T) {
 		RunDoctor(configDir)
 	})
 
-	if !strings.Contains(out, "[ok] Claude sandbox image") {
+	if !strings.Contains(out, "[ok] Sandbox image") {
 		t.Errorf("expected cached sandbox image ok, got:\n%s", out)
 	}
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -170,7 +170,7 @@ func buildSandboxExecArgs(runtimePath, configDir string, sb sandbox.Type, comman
 		return nil, fmt.Errorf("getwd: %w", err)
 	}
 	base := sanitize.Base(filepath.Base(cwd))
-	image := resolveSandboxImageForExec(envOrDefault("SANDBOX_IMAGE", defaultSandboxImage()), sb)
+	image := strings.TrimSpace(envOrDefault("SANDBOX_IMAGE", defaultSandboxImage()))
 	envFile := envOrDefault("ENV_FILE", filepath.Join(configDir, ".env"))
 	runtimeBin := filepath.Base(runtimePath)
 
@@ -178,16 +178,23 @@ func buildSandboxExecArgs(runtimePath, configDir string, sb sandbox.Type, comman
 	if info, err := os.Stat(envFile); err == nil && !info.IsDir() {
 		args = append(args, "--env-file", envFile)
 	}
+	// The unified sandbox image dispatches between Claude Code and Codex at
+	// runtime via WALLFACER_AGENT. Set it to the requested sandbox so the
+	// entrypoint launches the right CLI.
+	args = append(args, "-e", "WALLFACER_AGENT="+string(sb))
 	if sb == sandbox.Claude {
-		args = append(args, "-v", "claude-config:/home/claude/.claude")
+		args = append(args, "-v", "claude-config:/home/agent/.claude")
 	}
 	if sb == sandbox.Codex {
-		// Mount the host's ~/.codex directory (read-only) into the container so
-		// the Codex CLI can authenticate without re-login.
+		// Mount the host's ~/.codex/auth.json (read-only) into the container
+		// so Codex can authenticate without re-login. Mount only the file —
+		// Codex 0.120+ writes config.toml and session state into ~/.codex at
+		// startup, which requires the directory itself to be writable inside
+		// the container.
 		if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
-			codexPath := filepath.Join(home, ".codex")
-			if info, err := os.Stat(filepath.Join(codexPath, "auth.json")); err == nil && !info.IsDir() {
-				args = append(args, "--mount", "type=bind,src="+codexPath+",dst=/home/codex/.codex,readonly,z")
+			authFile := filepath.Join(home, ".codex", "auth.json")
+			if info, err := os.Stat(authFile); err == nil && !info.IsDir() {
+				args = append(args, "--mount", "type=bind,src="+authFile+",dst=/home/agent/.codex/auth.json,readonly,z")
 			}
 		}
 	}
@@ -199,49 +206,6 @@ func buildSandboxExecArgs(runtimePath, configDir string, sb sandbox.Type, comman
 	)
 	args = append(args, command...)
 	return args, nil
-}
-
-// resolveSandboxImageForExec derives the correct container image for the given
-// sandbox type. For Codex, it rewrites "sandbox-claude" image names to
-// "sandbox-codex" while preserving the registry prefix, tag, and digest.
-// Non-sandbox-claude images and Claude sandboxes are returned unchanged.
-func resolveSandboxImageForExec(baseImage string, sb sandbox.Type) string {
-	baseImage = strings.TrimSpace(baseImage)
-	if sb != sandbox.Codex {
-		return baseImage
-	}
-	if baseImage == "" {
-		return "sandbox-codex:latest"
-	}
-	low := strings.ToLower(baseImage)
-	if strings.Contains(low, "sandbox-codex") {
-		return baseImage
-	}
-
-	// Decompose the image reference into components:
-	//   [registry/prefix/]sandbox-claude[:tag][@digest]
-	// so we can swap "sandbox-claude" for "sandbox-codex" while keeping everything else.
-	registry := baseImage
-	digest := ""
-	if at := strings.Index(registry, "@"); at != -1 {
-		digest = registry[at:]
-		registry = registry[:at]
-	}
-	tag := ""
-	if at := strings.LastIndex(registry, ":"); at != -1 {
-		tag = registry[at:]
-		registry = registry[:at]
-	}
-	prefix := ""
-	repoName := registry
-	if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-		prefix = repoName[:idx+1]
-		repoName = repoName[idx+1:]
-	}
-	if repoName != "sandbox-claude" {
-		return baseImage // not a sandbox-claude image; return as-is
-	}
-	return prefix + "sandbox-codex" + tag + digest
 }
 
 // resolveContainerByPrefix searches the newline-separated output of

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -71,24 +71,6 @@ func TestParseExecConfig_SandboxRejectsInvalidRuntime(t *testing.T) {
 	}
 }
 
-// TestResolveSandboxImageForExec_CodexFromWallfacer verifies that "sandbox-claude:latest"
-// is rewritten to "sandbox-codex:latest" for the Codex sandbox.
-func TestResolveSandboxImageForExec_CodexFromWallfacer(t *testing.T) {
-	got := resolveSandboxImageForExec("sandbox-claude:latest", "codex")
-	if got != "sandbox-codex:latest" {
-		t.Fatalf("expected sandbox-codex:latest, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_CodexKeepsUnrelatedImage verifies that non-wallfacer
-// images are returned unchanged even when Codex sandbox is requested.
-func TestResolveSandboxImageForExec_CodexKeepsUnrelatedImage(t *testing.T) {
-	got := resolveSandboxImageForExec("ghcr.io/acme/custom:tag", "codex")
-	if got != "ghcr.io/acme/custom:tag" {
-		t.Fatalf("expected unchanged image, got %q", got)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // resolveContainerByPrefix
 // ---------------------------------------------------------------------------
@@ -221,8 +203,11 @@ func TestBuildSandboxExecArgs_UsesDefaultWorkspaceMount(t *testing.T) {
 	if !strings.Contains(got, "--env-file "+filepath.Join(tmp, ".env")) {
 		t.Fatalf("expected env-file arg, got %q", got)
 	}
-	if !strings.Contains(got, "-v claude-config:/home/claude/.claude") {
+	if !strings.Contains(got, "-v claude-config:/home/agent/.claude") {
 		t.Fatalf("expected claude config mount, got %q", got)
+	}
+	if !strings.Contains(got, "-e WALLFACER_AGENT=claude") {
+		t.Fatalf("expected WALLFACER_AGENT=claude env, got %q", got)
 	}
 	if !strings.Contains(got, "--mount type=bind,src="+tmp+",dst=/workspace/"+base+",z") {
 		t.Fatalf("expected repository workspace mount, got %q", got)
@@ -261,56 +246,15 @@ func TestBuildSandboxExecArgs_UsesCodexAuthWhenAvailable(t *testing.T) {
 	if !strings.Contains(got, expectedWorkspaceMount) {
 		t.Fatalf("expected workspace mount, got %q", got)
 	}
-	if !strings.Contains(got, "--mount type=bind,src="+authDir+",dst=/home/codex/.codex,readonly,z") {
-		t.Fatalf("expected codex auth mount, got %q", got)
+	authFile := filepath.Join(authDir, "auth.json")
+	if !strings.Contains(got, "--mount type=bind,src="+authFile+",dst=/home/agent/.codex/auth.json,readonly,z") {
+		t.Fatalf("expected codex auth.json mount, got %q", got)
+	}
+	if !strings.Contains(got, "-e WALLFACER_AGENT=codex") {
+		t.Fatalf("expected WALLFACER_AGENT=codex env, got %q", got)
 	}
 	if !strings.Contains(got, "--mount type=bind,src="+tmp+",dst=/workspace/"+base+",z") {
 		t.Fatalf("expected repository workspace mount, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_ClonesDockerImageTagAndDigest verifies that
-// both the tag and digest portions are preserved when rewriting a sandbox-claude
-// image to sandbox-codex.
-func TestResolveSandboxImageForExec_ClonesDockerImageTagAndDigest(t *testing.T) {
-	got := resolveSandboxImageForExec("ghcr.io/acme/sandbox-claude:latest@sha256:12345", "codex")
-	if got != "ghcr.io/acme/sandbox-codex:latest@sha256:12345" {
-		t.Fatalf("expected converted digest image, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_EmptyImage verifies that an empty image
-// returns sandbox-codex:latest for Codex sandbox.
-func TestResolveSandboxImageForExec_EmptyImage(t *testing.T) {
-	got := resolveSandboxImageForExec("", "codex")
-	if got != "sandbox-codex:latest" {
-		t.Fatalf("expected sandbox-codex:latest, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_AlreadyCodex verifies that an image already
-// containing "sandbox-codex" is returned unchanged.
-func TestResolveSandboxImageForExec_AlreadyCodex(t *testing.T) {
-	got := resolveSandboxImageForExec("ghcr.io/acme/sandbox-codex:v1", "codex")
-	if got != "ghcr.io/acme/sandbox-codex:v1" {
-		t.Fatalf("expected unchanged image, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_ClaudeReturnsUnchanged verifies that Claude
-// sandbox type returns the image unchanged regardless of content.
-func TestResolveSandboxImageForExec_ClaudeReturnsUnchanged(t *testing.T) {
-	got := resolveSandboxImageForExec("wallfacer:v2", "claude")
-	if got != "wallfacer:v2" {
-		t.Fatalf("expected unchanged for claude, got %q", got)
-	}
-}
-
-// TestResolveSandboxImageForExec_WhitespaceImage verifies whitespace trimming.
-func TestResolveSandboxImageForExec_WhitespaceImage(t *testing.T) {
-	got := resolveSandboxImageForExec("  sandbox-claude:latest  ", "codex")
-	if got != "sandbox-codex:latest" {
-		t.Fatalf("expected trimmed and rewritten image, got %q", got)
 	}
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -43,7 +43,7 @@ func newTestServer(t *testing.T) (*httptest.Server, *runner.MockRunner, *store.S
 	mock := &runner.MockRunner{
 		EnvFilePath: envPath,
 		Cmd:         "true",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		WtDir:       filepath.Join(workdir, "wt"),
 	}
 

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -259,27 +259,6 @@ func TestDefaultSandboxImage_DevBuild(t *testing.T) {
 	// Resolved a real tag (e.g. "v0.0.4") — valid.
 }
 
-func TestCodexImageFromClaude(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"sandbox-claude:latest", "sandbox-codex:latest"},
-		{"ghcr.io/latere-ai/sandbox-claude:v0.0.1", "ghcr.io/latere-ai/sandbox-codex:v0.0.1"},
-		{"ghcr.io/latere-ai/sandbox-claude:latest@sha256:abc", "ghcr.io/latere-ai/sandbox-codex:latest@sha256:abc"},
-		{"sandbox-codex:latest", "sandbox-codex:latest"},      // already codex
-		{"custom-image:latest", "custom-image:latest"},        // unrelated
-		{"", "sandbox-codex:latest"},                          // empty
-		{"  sandbox-claude:latest  ", "sandbox-codex:latest"}, // whitespace
-	}
-	for _, tt := range tests {
-		got := codexImageFromClaude(tt.input)
-		if got != tt.want {
-			t.Errorf("codexImageFromClaude(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 // TestDetectContainerRuntime_EnvOverride verifies that CONTAINER_CMD env var
 // overrides all other detection logic.
 func TestDetectContainerRuntime_EnvOverride(t *testing.T) {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -133,10 +133,6 @@ func initServer(configDir string, cfg ServerConfig, uiFS, docsFS fs.FS) *ServerC
 	}
 
 	resolvedImage := ensureImage(cfg.ContainerCmd, cfg.SandboxImage)
-	codexImage := codexImageFromClaude(resolvedImage)
-	if codexImage != resolvedImage {
-		ensureImage(cfg.ContainerCmd, codexImage)
-	}
 	codexAuthPath := ""
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		codexAuthPath = filepath.Join(home, ".codex")
@@ -1021,7 +1017,7 @@ func loggingMiddleware(next http.Handler, reg *metrics.Registry) http.Handler {
 
 // ensureImage checks whether the sandbox image is present locally and pulls it
 // from the registry if it is not.  When the pull fails and a local fallback
-// image (sandbox-claude:latest) is available, that image is used instead.
+// image (sandbox-agents:latest) is available, that image is used instead.
 // Returns the image reference that should actually be used.
 func ensureImage(containerCmd, image string) string {
 	out, err := cmdexec.New(containerCmd, "images", "-q", image).Output()

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -35,7 +35,7 @@ func TestInitServer(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 	defer sc.Shutdown()
@@ -179,7 +179,7 @@ func TestEnsureImage_ReturnsExistingOrPulledImage(t *testing.T) {
 	runtimeScript := filepath.Join(tmp, "runtime.sh")
 	if err := os.WriteFile(runtimeScript, []byte("#!/bin/sh\n"+
 		"if [ \"$1\" = \"images\" ]; then\n"+
-		"  if [ \"$2\" = \"-q\" ] && [ \"$3\" = \"sandbox-claude:latest\" ]; then\n"+
+		"  if [ \"$2\" = \"-q\" ] && [ \"$3\" = \"sandbox-agents:latest\" ]; then\n"+
 		"    echo found\n"+
 		"  fi\n"+
 		"  exit 0\n"+
@@ -189,14 +189,14 @@ func TestEnsureImage_ReturnsExistingOrPulledImage(t *testing.T) {
 		t.Fatalf("write runtime script: %v", err)
 	}
 
-	got := ensureImage(runtimeScript, "sandbox-claude:latest")
-	if got != "sandbox-claude:latest" {
+	got := ensureImage(runtimeScript, "sandbox-agents:latest")
+	if got != "sandbox-agents:latest" {
 		t.Fatalf("expected requested image, got %q", got)
 	}
 }
 
 // TestEnsureImage_UsesFallbackWhenPullFails verifies that ensureImage falls
-// back to sandbox-claude:latest when the requested image is not cached and the
+// back to sandbox-agents:latest when the requested image is not cached and the
 // pull fails.
 func TestEnsureImage_UsesFallbackWhenPullFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -206,7 +206,7 @@ func TestEnsureImage_UsesFallbackWhenPullFails(t *testing.T) {
 	runtimeScript := filepath.Join(tmp, "runtime.sh")
 	if err := os.WriteFile(runtimeScript, []byte("#!/bin/sh\n"+
 		"if [ \"$1\" = \"images\" ]; then\n"+
-		"  if [ \"$2\" = \"-q\" ] && [ \"$3\" = \"sandbox-claude:latest\" ]; then\n"+
+		"  if [ \"$2\" = \"-q\" ] && [ \"$3\" = \"sandbox-agents:latest\" ]; then\n"+
 		"    echo found\n"+
 		"  elif [ \"$2\" = \"-q\" ] && [ \"$3\" = \"wallfacer-missing:latest\" ]; then\n"+
 		"    :\n"+
@@ -219,7 +219,7 @@ func TestEnsureImage_UsesFallbackWhenPullFails(t *testing.T) {
 	}
 
 	got := ensureImage(runtimeScript, "wallfacer-missing:latest")
-	if got != "sandbox-claude:latest" {
+	if got != "sandbox-agents:latest" {
 		t.Fatalf("expected fallback image, got %q", got)
 	}
 }
@@ -689,8 +689,8 @@ func TestEnsureImage_SameAsFallback(t *testing.T) {
 		t.Fatalf("write script: %v", err)
 	}
 
-	got := ensureImage(runtimeScript, "sandbox-claude:latest")
-	if got != "sandbox-claude:latest" {
+	got := ensureImage(runtimeScript, "sandbox-agents:latest")
+	if got != "sandbox-agents:latest" {
 		t.Fatalf("expected original image, got %q", got)
 	}
 }
@@ -733,7 +733,7 @@ func TestInitServer_MetricsScrapesGauges(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 	defer sc.Shutdown()
@@ -780,7 +780,7 @@ func TestInitServer_WithExistingStore(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 	defer sc.Shutdown()
@@ -813,7 +813,7 @@ func TestInitServer_PortFallback(t *testing.T) {
 		Addr:         fmt.Sprintf(":%d", occupiedPort),
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 	defer sc.Shutdown()
@@ -842,7 +842,7 @@ func TestInitServer_TombstoneRetentionDays(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 	defer sc.Shutdown()
@@ -866,7 +866,7 @@ func TestShutdown_WithPlannerRunning(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 
@@ -888,7 +888,7 @@ func TestShutdown_HttpShutdownError(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	}, testFS(t), testFS(t))
 
@@ -912,7 +912,7 @@ func TestInitServer_SkipCSRF(t *testing.T) {
 		Addr:         ":0",
 		DataDir:      filepath.Join(configDir, "data"),
 		ContainerCmd: "true",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 		SkipCSRF:     true,
 	}, testFS(t), testFS(t))

--- a/internal/handler/config.go
+++ b/internal/handler/config.go
@@ -235,20 +235,15 @@ func (h *Handler) buildConfigResponse(ctx context.Context, cfg *envconfig.Config
 	sandboxReasons := map[string]string{}
 
 	// Gate sandboxes on image availability first, then credential checks.
-	// Skip when no container runtime is configured (e.g. unit tests).
+	// Both Claude and Codex sandboxes share the unified sandbox-agents
+	// image, so a single check covers both. Skip when no container
+	// runtime is configured (e.g. unit tests).
 	if h.runner != nil && h.runner.Command() != "" {
 		cmd := h.runner.Command()
-		claudeImage := h.runner.SandboxImage()
-		codexImage := testCodexImage(claudeImage)
-		for _, sbox := range sandboxes {
-			var image string
-			if sbox == sandbox.Codex {
-				image = codexImage
-			} else {
-				image = claudeImage
-			}
-			status := h.inspectImage(cmd, sbox, image)
-			if !status.Cached {
+		image := h.runner.SandboxImage()
+		status := h.inspectImage(cmd, sandbox.Claude, image)
+		if !status.Cached {
+			for _, sbox := range sandboxes {
 				sandboxUsable[sbox] = false
 				sandboxReasons[string(sbox)] = string(sbox) + " unavailable: sandbox image not cached. Pull it from Settings → Sandbox Images."
 			}

--- a/internal/handler/env.go
+++ b/internal/handler/env.go
@@ -19,10 +19,6 @@ import (
 	"changkun.de/x/wallfacer/internal/store"
 )
 
-// fallbackCodexSandboxImage is used when the base Claude image is empty or
-// unrecognised, ensuring Codex always has a usable image name.
-const fallbackCodexSandboxImage = "sandbox-codex:latest"
-
 // privateIPNets lists networks blocked for SSRF prevention: RFC 1918 private
 // ranges, loopback (IPv4 and IPv6), and link-local ranges. Populated once at
 // init to avoid repeated CIDR parsing on every validateBaseURL call.
@@ -398,54 +394,10 @@ func (h *Handler) buildTestEnvFile(req *sandboxTestRequest) (string, error) {
 }
 
 // sandboxImageForTest returns the container image name to use for a sandbox
-// connectivity test. For Codex it derives the image from the base Claude image.
-func sandboxImageForTest(sb sandbox.Type, baseImage string) string {
-	if sb == sandbox.Codex {
-		return testCodexImage(baseImage)
-	}
+// connectivity test. The unified sandbox-agents image serves both Claude and
+// Codex; the agent CLI is selected at runtime via WALLFACER_AGENT.
+func sandboxImageForTest(_ sandbox.Type, baseImage string) string {
 	return strings.TrimSpace(baseImage)
-}
-
-// testCodexImage derives the Codex sandbox image name from the Claude base
-// image by replacing the repository name "sandbox-claude" with "sandbox-codex"
-// while preserving registry, tag, and digest components.
-func testCodexImage(baseImage string) string {
-	baseImage = strings.TrimSpace(baseImage)
-	if baseImage == "" {
-		return fallbackCodexSandboxImage
-	}
-
-	low := strings.ToLower(baseImage)
-	if strings.Contains(low, "sandbox-codex") {
-		return baseImage
-	}
-
-	registry := baseImage
-	digest := ""
-	if at := strings.Index(registry, "@"); at != -1 {
-		digest = registry[at:]
-		registry = registry[:at]
-	}
-
-	// Assume tag format <repo>:<tag> and preserve host:port if present.
-	tag := ""
-	if at := strings.LastIndex(registry, ":"); at != -1 {
-		tag = registry[at:]
-		registry = registry[:at]
-	}
-
-	prefix := ""
-	repoName := registry
-	if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-		prefix = repoName[:idx+1]
-		repoName = repoName[idx+1:]
-	}
-
-	if repoName != "sandbox-claude" {
-		return baseImage
-	}
-
-	return prefix + "sandbox-codex" + tag + digest
 }
 
 // UpdateEnvConfig writes changes to the env file.

--- a/internal/handler/env_test.go
+++ b/internal/handler/env_test.go
@@ -487,52 +487,19 @@ func TestTestSandbox_InvalidBaseURLRejected(t *testing.T) {
 	}
 }
 
-func TestSandboxImageForTest_CodexResolution(t *testing.T) {
-	tests := []struct {
-		name    string
-		sandbox string
-		inImage string
-		want    string
-	}{
-		{
-			name:    "codex uses wallfacer-codex default image",
-			sandbox: "codex",
-			inImage: "sandbox-claude:latest",
-			want:    "sandbox-codex:latest",
-		},
-		{
-			name:    "codex preserves hosted wallfacer image family",
-			sandbox: "codex",
-			inImage: "ghcr.io/latere-ai/sandbox-claude:latest",
-			want:    "ghcr.io/latere-ai/sandbox-codex:latest",
-		},
-		{
-			name:    "codex keeps preconfigured codex image",
-			sandbox: "codex",
-			inImage: "sandbox-codex:latest",
-			want:    "sandbox-codex:latest",
-		},
-		{
-			name:    "claude keeps default image",
-			sandbox: "claude",
-			inImage: "sandbox-claude:latest",
-			want:    "sandbox-claude:latest",
-		},
-		{
-			name:    "codex default fallback",
-			sandbox: "codex",
-			inImage: "",
-			want:    fallbackCodexSandboxImage,
-		},
+// TestSandboxImageForTest verifies the unified-image behavior: the same
+// image is used for every sandbox type. The agent CLI is selected via
+// WALLFACER_AGENT inside the container, not via the image name.
+func TestSandboxImageForTest(t *testing.T) {
+	const image = "ghcr.io/latere-ai/sandbox-agents:v0.0.5"
+	for _, sb := range []sandbox.Type{sandbox.Claude, sandbox.Codex} {
+		got := sandboxImageForTest(sb, image)
+		if got != image {
+			t.Fatalf("sandboxImageForTest(%q, %q) = %q; want %q", sb, image, got, image)
+		}
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sandboxImageForTest(sandbox.Type(tt.sandbox), tt.inImage)
-			if got != tt.want {
-				t.Fatalf("sandboxImageForTest(%q, %q) = %q; want %q", tt.sandbox, tt.inImage, got, tt.want)
-			}
-		})
+	if got := sandboxImageForTest(sandbox.Codex, "  spaced  "); got != "spaced" {
+		t.Fatalf("expected whitespace-trimmed image, got %q", got)
 	}
 }
 

--- a/internal/handler/images.go
+++ b/internal/handler/images.go
@@ -154,15 +154,16 @@ func scanLinesOrCR(data []byte, atEOF bool) (advance int, token []byte, err erro
 	return 0, nil, nil
 }
 
-// GetImageStatus returns the availability of sandbox images.
+// GetImageStatus returns the availability of the unified sandbox image.
+// The legacy split images have collapsed into a single sandbox-agents
+// image; the response keeps the array shape for UI compatibility but
+// always contains exactly one entry.
 func (h *Handler) GetImageStatus(w http.ResponseWriter, _ *http.Request) {
 	cmd := h.runner.Command()
-	claudeImage := h.runner.SandboxImage()
-	codexImage := testCodexImage(claudeImage)
+	image := h.runner.SandboxImage()
 
 	images := []imageStatus{
-		h.inspectImage(cmd, sandbox.Claude, claudeImage),
-		h.inspectImage(cmd, sandbox.Codex, codexImage),
+		h.inspectImage(cmd, sandbox.Claude, image),
 	}
 
 	httpjson.Write(w, http.StatusOK, map[string]any{
@@ -206,12 +207,10 @@ func (h *Handler) DeleteImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sb := sandbox.Default(req.Sandbox)
-	claudeImage := h.runner.SandboxImage()
-	image := claudeImage
-	if sb == sandbox.Codex {
-		image = testCodexImage(claudeImage)
-	}
+	// The unified sandbox-agents image serves both Claude and Codex; the
+	// req.Sandbox field is accepted for API compatibility but ignored.
+	_ = req
+	image := h.runner.SandboxImage()
 
 	cmd := h.runner.Command()
 	if cmd == "" || image == "" {
@@ -236,12 +235,10 @@ func (h *Handler) PullImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sb := sandbox.Default(req.Sandbox)
-	claudeImage := h.runner.SandboxImage()
-	image := claudeImage
-	if sb == sandbox.Codex {
-		image = testCodexImage(claudeImage)
-	}
+	// The unified sandbox-agents image serves both Claude and Codex; the
+	// req.Sandbox field is accepted for API compatibility but ignored.
+	_ = req
+	image := h.runner.SandboxImage()
 	if image == "" {
 		http.Error(w, "no sandbox image configured", http.StatusBadRequest)
 		return
@@ -262,7 +259,7 @@ func (h *Handler) PullImage(w http.ResponseWriter, r *http.Request) {
 	p := &imagePull{
 		ID:      uuid.New().String(),
 		Image:   image,
-		Sandbox: sb,
+		Sandbox: sandbox.Claude,
 		Lines:   make(chan string, 64),
 		Done:    make(chan struct{}),
 	}

--- a/internal/handler/images_test.go
+++ b/internal/handler/images_test.go
@@ -26,15 +26,14 @@ func TestGetImageStatus_ReturnsImages(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected images array, got %T", resp["images"])
 	}
-	if len(images) != 2 {
-		t.Fatalf("expected 2 images (claude + codex), got %d", len(images))
+	// The unified sandbox-agents image returns a single entry; the legacy
+	// per-agent images have been collapsed.
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image (unified sandbox-agents), got %d", len(images))
 	}
-	// With test runner (empty config), both should be uncached.
-	for _, img := range images {
-		m := img.(map[string]any)
-		if m["cached"].(bool) {
-			t.Errorf("expected cached=false for test handler, got true for %v", m["sandbox"])
-		}
+	m := images[0].(map[string]any)
+	if m["cached"].(bool) {
+		t.Errorf("expected cached=false for test handler, got true for %v", m["sandbox"])
 	}
 }
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -16,7 +16,7 @@ import (
 func TestPlannerNew(t *testing.T) {
 	cfg := Config{
 		Command:     "/usr/bin/podman",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		Workspaces:  []string{"/home/user/repo"},
 		EnvFile:     "/home/user/.env",
 		Fingerprint: "abc123def456",
@@ -121,7 +121,7 @@ func TestBuildContainerSpec(t *testing.T) {
 
 	p := New(Config{
 		Command:          "/usr/bin/podman",
-		Image:            "sandbox-claude:latest",
+		Image:            "sandbox-agents:latest",
 		Workspaces:       []string{tmpDir},
 		EnvFile:          "/tmp/test.env",
 		Fingerprint:      "abc123",
@@ -137,8 +137,8 @@ func TestBuildContainerSpec(t *testing.T) {
 	if spec.Name != "wallfacer-plan-test" {
 		t.Errorf("Name = %q, want %q", spec.Name, "wallfacer-plan-test")
 	}
-	if spec.Image != "sandbox-claude:latest" {
-		t.Errorf("Image = %q, want %q", spec.Image, "sandbox-claude:latest")
+	if spec.Image != "sandbox-agents:latest" {
+		t.Errorf("Image = %q, want %q", spec.Image, "sandbox-agents:latest")
 	}
 	if spec.EnvFile != "/tmp/test.env" {
 		t.Errorf("EnvFile = %q, want %q", spec.EnvFile, "/tmp/test.env")
@@ -215,7 +215,7 @@ func TestBuildContainerSpecMultiWorkspace(t *testing.T) {
 
 	p := New(Config{
 		Command:     "podman",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		Workspaces:  []string{tmpDir1, tmpDir2},
 		Fingerprint: "multi",
 	})
@@ -257,7 +257,7 @@ func TestBuildContainerSpecNoSpecsDir(t *testing.T) {
 
 	p := New(Config{
 		Command:     "podman",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		Workspaces:  []string{tmpDir},
 		Fingerprint: "nospecs",
 	})
@@ -465,7 +465,7 @@ func TestAppendInstructionsMount_Codex(t *testing.T) {
 
 	p := New(Config{
 		Command:          "podman",
-		Image:            "sandbox-claude:latest",
+		Image:            "sandbox-agents:latest",
 		Workspaces:       []string{"/workspace/repo"},
 		InstructionsPath: instrFile,
 	})
@@ -516,7 +516,7 @@ func TestAppendInstructionsMount_MissingFile(t *testing.T) {
 func TestBuildContainerSpec_EmptyWorkspace(t *testing.T) {
 	p := New(Config{
 		Command:     "podman",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		Workspaces:  []string{"", "  "},
 		Fingerprint: "fp",
 	})
@@ -531,7 +531,7 @@ func TestBuildContainerSpec_EmptyWorkspace(t *testing.T) {
 func TestBuildContainerSpec_NoEnvFile(t *testing.T) {
 	p := New(Config{
 		Command:     "podman",
-		Image:       "sandbox-claude:latest",
+		Image:       "sandbox-agents:latest",
 		Workspaces:  []string{t.TempDir()},
 		Fingerprint: "fp",
 	})

--- a/internal/planner/spec.go
+++ b/internal/planner/spec.go
@@ -32,7 +32,7 @@ func (p *Planner) buildContainerSpec(containerName string, sb sandbox.Type) sand
 	// claude-config named volume for agent configuration persistence.
 	spec.Volumes = append(spec.Volumes, sandbox.VolumeMount{
 		Host:      "claude-config",
-		Container: "/home/claude/.claude",
+		Container: "/home/agent/.claude",
 		Named:     true,
 	})
 

--- a/internal/runner/container.go
+++ b/internal/runner/container.go
@@ -275,29 +275,44 @@ func buildAgentCmd(prompt, model string) []string {
 	return cmd
 }
 
-// appendCodexAuthMount adds the host Codex auth cache as a read-only bind
-// mount when the sandbox is Codex and the host path exists. No-op for other sandboxes.
+// appendCodexAuthMount adds the host Codex auth.json file as a read-only
+// bind mount when the sandbox is Codex and the file exists. No-op for
+// other sandboxes.
+//
+// Only the file is mounted (not the entire ~/.codex directory): codex
+// 0.120+ writes config.toml and session state into $HOME/.codex at
+// startup, so the directory itself must remain writable inside the
+// container. Mounting the whole dir read-only would break the CLI;
+// mounting it read-write would let the container clobber host state.
 func (r *Runner) appendCodexAuthMount(volumes []sandbox.VolumeMount, sb sandbox.Type) []sandbox.VolumeMount {
 	if sb != sandbox.Codex {
 		return volumes
 	}
-	if hostPath := r.hostCodexAuthPath(); hostPath != "" {
+	if hostDir := r.hostCodexAuthPath(); hostDir != "" {
 		volumes = append(volumes, sandbox.VolumeMount{
-			Host:      hostPath,
-			Container: "/home/codex/.codex",
+			Host:      filepath.Join(hostDir, "auth.json"),
+			Container: "/home/agent/.codex/auth.json",
 			Options:   mountOpts("z", "ro"),
 		})
 	}
 	return volumes
 }
 
+// sandboxEntrypoint is the in-image dispatcher script. The sandbox-agents
+// image installs a single entrypoint that reads WALLFACER_AGENT to decide
+// whether to launch claude-agent.sh or codex-agent.sh; both classic and
+// worker exec invocations point at the same path.
+const sandboxEntrypoint = "/usr/local/bin/entrypoint.sh"
+
 // buildBaseContainerSpec creates a ContainerSpec pre-populated with the
 // configuration shared across all sub-agent invocations:
-//   - Runtime, Name, and Image resolved from the configured sandbox
+//   - Runtime, Name, and the unified sandbox-agents image
 //   - EnvFile (when configured)
+//   - WALLFACER_AGENT environment variable (claude or codex) so the image
+//     entrypoint dispatches to the correct CLI
 //   - CLAUDE_CODE_MODEL environment variable (when model is non-empty)
 //   - claude-config named volume for agent configuration persistence
-//   - Codex auth bind-mount (when sandbox=="codex" and the path exists on the host)
+//   - Codex auth.json bind-mount (when sandbox=="codex" and the file exists)
 //
 // Callers set Labels, additional Volumes (workspace directories, instructions
 // file, board context), WorkDir, and Cmd for their specific needs.
@@ -305,52 +320,40 @@ func (r *Runner) buildBaseContainerSpec(containerName, model string, sb sandbox.
 	spec := sandbox.ContainerSpec{
 		Runtime: r.command,
 		Name:    containerName,
-		Image:   r.sandboxImageForSandbox(sb),
+		Image:   strings.TrimSpace(r.sandboxImage),
 	}
 	if r.envFile != "" {
 		spec.EnvFile = r.envFile
 	}
+	spec.Env = map[string]string{"WALLFACER_AGENT": string(sb)}
 	if model != "" {
-		spec.Env = map[string]string{"CLAUDE_CODE_MODEL": model}
+		spec.Env["CLAUDE_CODE_MODEL"] = model
 	}
 	spec.Volumes = append(spec.Volumes, sandbox.VolumeMount{
 		Host:      "claude-config",
-		Container: "/home/claude/.claude",
+		Container: "/home/agent/.claude",
 		Named:     true,
 	})
 	spec.Volumes = r.appendCodexAuthMount(spec.Volumes, sb)
 	spec.Volumes = r.appendDependencyCacheVolumes(spec.Volumes)
-	spec.Entrypoint = entrypointForSandbox(sb)
+	spec.Entrypoint = sandboxEntrypoint
 	spec.Network = r.resolvedContainerNetwork()
 	spec.CPUs = r.resolvedContainerCPUs()
 	spec.Memory = r.resolvedContainerMemory()
 	return spec
 }
 
-// entrypointForSandbox returns the entrypoint script path for the given
-// sandbox type. This is needed because podman exec does not invoke the
-// image ENTRYPOINT automatically; worker containers must prepend it.
-// Both sandbox types currently use the same path; the switch exists to
-// make future divergence explicit without requiring a code restructure.
-func entrypointForSandbox(sb sandbox.Type) string {
-	switch sb {
-	case sandbox.Codex:
-		return "/usr/local/bin/entrypoint.sh"
-	default:
-		return "/usr/local/bin/entrypoint.sh"
-	}
-}
-
 // dependencyCacheVolumes are the common dependency cache directories
 // mounted as named volumes so warm caches persist across container lifetimes.
+// Paths target the unified sandbox-agents image's `agent` user home.
 var dependencyCacheVolumes = []struct {
 	suffix    string // volume name suffix (e.g. "npm")
 	container string // container path
 }{
-	{"npm", "/home/claude/.npm"},
-	{"pip", "/home/claude/.cache/pip"},
-	{"cargo", "/home/claude/.cargo/registry"},
-	{"go-build", "/home/claude/.cache/go-build"},
+	{"npm", "/home/agent/.npm"},
+	{"pip", "/home/agent/.cache/pip"},
+	{"cargo", "/home/agent/.cargo/registry"},
+	{"go-build", "/home/agent/.cache/go-build"},
 }
 
 // appendDependencyCacheVolumes adds named volumes for dependency caches when
@@ -378,43 +381,6 @@ func (r *Runner) appendDependencyCacheVolumes(volumes []sandbox.VolumeMount) []s
 	return volumes
 }
 
-// sandboxImageForSandbox derives the container image name for the given sandbox type.
-// For Claude it returns the configured sandboxImage as-is. For Codex it rewrites
-// "sandbox-claude" → "sandbox-codex" in the image name (preserving registry, tag, and digest).
-func (r *Runner) sandboxImageForSandbox(sb sandbox.Type) string {
-	if sb != sandbox.Codex {
-		return strings.TrimSpace(r.sandboxImage)
-	}
-	baseImage := strings.TrimSpace(r.sandboxImage)
-	if baseImage == "" {
-		return "sandbox-codex:latest"
-	}
-	low := strings.ToLower(baseImage)
-	if strings.Contains(low, "sandbox-codex") {
-		return baseImage
-	}
-	registry := baseImage
-	digest := ""
-	if at := strings.Index(registry, "@"); at != -1 {
-		digest = registry[at:]
-		registry = registry[:at]
-	}
-	tag := ""
-	if at := strings.LastIndex(registry, ":"); at != -1 {
-		tag = registry[at:]
-		registry = registry[:at]
-	}
-	prefix := ""
-	repoName := registry
-	if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-		prefix = repoName[:idx+1]
-		repoName = repoName[idx+1:]
-	}
-	if repoName != "sandbox-claude" {
-		return baseImage
-	}
-	return prefix + "sandbox-codex" + tag + digest
-}
 
 // sandboxForTask returns the resolved sandbox type for the task's implementation activity.
 // Shorthand for sandboxForTaskActivity(task, activityImplementation).

--- a/internal/runner/container_builder_test.go
+++ b/internal/runner/container_builder_test.go
@@ -58,44 +58,44 @@ func TestBuildBaseContainerSpec(t *testing.T) {
 		{
 			name: "claude, no envfile, no model",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"}
 			},
 			model:   "",
 			sandbox: "claude",
 			wantPairs: []pair{
 				{"--name", "c-test"},
-				{"-v", "claude-config:/home/claude/.claude"},
+				{"-v", "claude-config:/home/agent/.claude"},
 			},
-			wantArgs:    []string{"sandbox-claude:latest"},
-			wantNotArgs: []string{"--env-file", "CLAUDE_CODE_MODEL", "/home/codex"},
+			wantArgs:    []string{"sandbox-agents:latest"},
+			wantNotArgs: []string{"--env-file", "CLAUDE_CODE_MODEL", "/home/agent/.codex"},
 		},
 		{
 			name: "claude, with envfile and model",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest", EnvFile: "/home/user/.env"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest", EnvFile: "/home/user/.env"}
 			},
 			model:   "claude-opus-4-6",
 			sandbox: "claude",
 			wantPairs: []pair{
 				{"--env-file", "/home/user/.env"},
 				{"-e", "CLAUDE_CODE_MODEL=claude-opus-4-6"},
-				{"-v", "claude-config:/home/claude/.claude"},
+				{"-v", "claude-config:/home/agent/.claude"},
 			},
-			wantArgs:    []string{"sandbox-claude:latest"},
-			wantNotArgs: []string{"/home/codex"},
+			wantArgs:    []string{"sandbox-agents:latest"},
+			wantNotArgs: []string{"/home/agent/.codex"},
 		},
 		{
 			name: "codex sandbox, no auth path configured",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"}
 			},
 			model:   "",
 			sandbox: "codex",
 			wantPairs: []pair{
-				{"-v", "claude-config:/home/claude/.claude"},
+				{"-v", "claude-config:/home/agent/.claude"},
 			},
-			wantArgs:    []string{"sandbox-codex:latest"},
-			wantNotArgs: []string{"/home/codex"},
+			wantArgs:    []string{"sandbox-agents:latest"},
+			wantNotArgs: []string{"/home/agent/.codex"},
 		},
 		{
 			name: "codex sandbox, with valid auth path",
@@ -105,37 +105,43 @@ func TestBuildBaseContainerSpec(t *testing.T) {
 				if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{}`), 0600); err != nil {
 					t.Fatal(err)
 				}
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest", CodexAuthPath: dir}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest", CodexAuthPath: dir}
 			},
 			model:   "codex-model",
 			sandbox: "codex",
 			wantPairs: []pair{
-				{"-v", "claude-config:/home/claude/.claude"},
+				{"-v", "claude-config:/home/agent/.claude"},
 				{"-e", "CLAUDE_CODE_MODEL=codex-model"},
+				{"-e", "WALLFACER_AGENT=codex"},
 			},
-			wantArgs: []string{"sandbox-codex:latest", "dst=/home/codex/.codex," + expectedBuildROSuffix()},
+			wantArgs: []string{"sandbox-agents:latest", "dst=/home/agent/.codex/auth.json," + expectedBuildROSuffix()},
 		},
 		{
 			name: "codex sandbox, auth path does not exist",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest", CodexAuthPath: "/nonexistent/path/to/codex"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest", CodexAuthPath: "/nonexistent/path/to/codex"}
 			},
 			model:       "",
 			sandbox:     "codex",
-			wantArgs:    []string{"sandbox-codex:latest"},
-			wantNotArgs: []string{"/home/codex"},
+			wantArgs:    []string{"sandbox-agents:latest"},
+			wantNotArgs: []string{"/home/agent/.codex"},
 		},
 		{
-			name:     "codex sandbox, empty sandbox image falls back to sandbox-codex:latest",
+			// With the unified sandbox-agents image, the runner no longer
+			// derives a fallback codex image — there is just one image, and
+			// an empty SandboxImage stays empty (caller is responsible for
+			// configuring it). The container spec still emits
+			// WALLFACER_AGENT=codex so the entrypoint dispatches correctly.
+			name:     "codex sandbox emits WALLFACER_AGENT regardless of image",
 			cfgFn:    func(_ *testing.T) RunnerConfig { return RunnerConfig{Command: "podman", SandboxImage: ""} },
 			model:    "",
 			sandbox:  "codex",
-			wantArgs: []string{"sandbox-codex:latest"},
+			wantArgs: []string{"WALLFACER_AGENT=codex"},
 		},
 		{
 			name: "network is always host",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"}
 			},
 			model:   "",
 			sandbox: "claude",
@@ -179,10 +185,12 @@ func TestBuildBaseContainerSpec(t *testing.T) {
 	}
 }
 
-// TestBuildBaseContainerSpecClaudeVsCodexImageDiffers verifies that the claude
-// and codex sandboxes resolve to different images from the same base image.
-func TestBuildBaseContainerSpecClaudeVsCodexImageDiffers(t *testing.T) {
-	r := newRunnerForArgTest(t, RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"})
+// TestBuildBaseContainerSpecClaudeVsCodexAgentEnv verifies that both
+// claude and codex sandboxes share the unified sandbox-agents image and
+// differ only in the WALLFACER_AGENT env var that the entrypoint reads
+// to dispatch to the right CLI.
+func TestBuildBaseContainerSpecClaudeVsCodexAgentEnv(t *testing.T) {
+	r := newRunnerForArgTest(t, RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"})
 
 	claudeSpec := r.buildBaseContainerSpec("c-test", "", "claude")
 	codexSpec := r.buildBaseContainerSpec("c-test", "", "codex")
@@ -190,14 +198,17 @@ func TestBuildBaseContainerSpecClaudeVsCodexImageDiffers(t *testing.T) {
 	claudeArgs := claudeSpec.Build()
 	codexArgs := codexSpec.Build()
 
-	if !argsContainSubstring(claudeArgs, "sandbox-claude:latest") {
-		t.Errorf("claude spec: expected sandbox-claude:latest; args: %v", claudeArgs)
+	if !argsContainSubstring(claudeArgs, "sandbox-agents:latest") {
+		t.Errorf("claude spec: expected sandbox-agents:latest; args: %v", claudeArgs)
 	}
-	if !argsContainSubstring(codexArgs, "sandbox-codex:latest") {
-		t.Errorf("codex spec: expected sandbox-codex:latest; args: %v", codexArgs)
+	if !argsContainSubstring(codexArgs, "sandbox-agents:latest") {
+		t.Errorf("codex spec: expected sandbox-agents:latest; args: %v", codexArgs)
 	}
-	if argsContainSubstring(claudeArgs, "sandbox-codex") {
-		t.Errorf("claude spec should not reference wallfacer-codex; args: %v", claudeArgs)
+	if !argsContainSubstring(claudeArgs, "WALLFACER_AGENT=claude") {
+		t.Errorf("claude spec: expected WALLFACER_AGENT=claude; args: %v", claudeArgs)
+	}
+	if !argsContainSubstring(codexArgs, "WALLFACER_AGENT=codex") {
+		t.Errorf("codex spec: expected WALLFACER_AGENT=codex; args: %v", codexArgs)
 	}
 }
 
@@ -211,7 +222,7 @@ func TestBuildBaseContainerSpecVolumeOrder(t *testing.T) {
 	}
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:       "podman",
-		SandboxImage:  "sandbox-claude:latest",
+		SandboxImage:  "sandbox-agents:latest",
 		CodexAuthPath: codexDir,
 	})
 
@@ -220,10 +231,10 @@ func TestBuildBaseContainerSpecVolumeOrder(t *testing.T) {
 
 	claudeIdx, codexIdx := -1, -1
 	for i := 0; i+1 < len(args); i++ {
-		if args[i] == "-v" && args[i+1] == "claude-config:/home/claude/.claude" {
+		if args[i] == "-v" && args[i+1] == "claude-config:/home/agent/.claude" {
 			claudeIdx = i
 		}
-		if args[i] == "--mount" && strings.Contains(args[i+1], "/home/codex/.codex") {
+		if args[i] == "--mount" && strings.Contains(args[i+1], "/home/agent/.codex") {
 			codexIdx = i
 		}
 	}
@@ -241,7 +252,7 @@ func TestBuildBaseContainerSpecVolumeOrder(t *testing.T) {
 // TestBuildBaseContainerSpecRuntimeNotInBuild verifies that Runtime is used
 // for exec.Command but does not appear in the Build() arg slice.
 func TestBuildBaseContainerSpecRuntimeNotInBuild(t *testing.T) {
-	r := newRunnerForArgTest(t, RunnerConfig{Command: "/opt/podman/bin/podman", SandboxImage: "sandbox-claude:latest"})
+	r := newRunnerForArgTest(t, RunnerConfig{Command: "/opt/podman/bin/podman", SandboxImage: "sandbox-agents:latest"})
 	spec := r.buildBaseContainerSpec("c-test", "", "claude")
 	args := spec.Build()
 
@@ -275,7 +286,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 				ws := t.TempDir()
 				return RunnerConfig{
 					Command:      "podman",
-					SandboxImage: "sandbox-claude:latest",
+					SandboxImage: "sandbox-agents:latest",
 					Workspaces:   []string{ws},
 				}
 			},
@@ -299,7 +310,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 				}
 				return RunnerConfig{
 					Command:      "podman",
-					SandboxImage: "sandbox-claude:latest",
+					SandboxImage: "sandbox-agents:latest",
 					Workspaces:   []string{ws1, ws2},
 				}
 			},
@@ -317,7 +328,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 				}
 				return RunnerConfig{
 					Command:          "podman",
-					SandboxImage:     "sandbox-claude:latest",
+					SandboxImage:     "sandbox-agents:latest",
 					InstructionsPath: instrPath,
 				}
 			},
@@ -333,7 +344,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 				}
 				return RunnerConfig{
 					Command:          "podman",
-					SandboxImage:     "sandbox-claude:latest",
+					SandboxImage:     "sandbox-agents:latest",
 					InstructionsPath: instrPath,
 				}
 			},
@@ -345,7 +356,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 			cfgFn: func(_ *testing.T) RunnerConfig {
 				return RunnerConfig{
 					Command:          "podman",
-					SandboxImage:     "sandbox-claude:latest",
+					SandboxImage:     "sandbox-agents:latest",
 					InstructionsPath: "/nonexistent/CLAUDE.md",
 				}
 			},
@@ -357,7 +368,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 			cfgFn: func(_ *testing.T) RunnerConfig {
 				return RunnerConfig{
 					Command:      "podman",
-					SandboxImage: "sandbox-claude:latest",
+					SandboxImage: "sandbox-agents:latest",
 				}
 			},
 			sandbox:     "claude",
@@ -366,7 +377,7 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 		{
 			name: "prompt is passed after image in Cmd",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"}
 			},
 			sandbox: "claude",
 			wantPairs: []pair{
@@ -376,10 +387,10 @@ func TestBuildIdeationContainerArgs(t *testing.T) {
 		{
 			name: "claude and codex produce different images",
 			cfgFn: func(_ *testing.T) RunnerConfig {
-				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-claude:latest"}
+				return RunnerConfig{Command: "podman", SandboxImage: "sandbox-agents:latest"}
 			},
 			sandbox:  "codex",
-			wantArgs: []string{"sandbox-codex:latest"},
+			wantArgs: []string{"sandbox-agents:latest"},
 		},
 	}
 
@@ -420,7 +431,7 @@ func TestBuildIdeationContainerArgsSingleWorkspaceReadOnly(t *testing.T) {
 
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		Workspaces:   []string{ws},
 	})
 	args := r.buildIdeationContainerArgs("ideate-test", "prompt", "claude")
@@ -461,7 +472,7 @@ func TestBuildIdeationContainerArgsSingleWorkspaceInstructionsInsideRepo(t *test
 
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		Workspaces:       []string{ws},
 		InstructionsPath: instrPath,
 	})
@@ -486,17 +497,17 @@ func TestBuildIdeationContainerArgsSingleWorkspaceInstructionsInsideRepo(t *test
 func TestBuildIdeationContainerArgsClaudeVsCodex(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 
 	claudeArgs := r.buildIdeationContainerArgs("ideate-test", "prompt", "claude")
 	codexArgs := r.buildIdeationContainerArgs("ideate-test", "prompt", "codex")
 
-	if !argsContainSubstring(claudeArgs, "sandbox-claude:latest") {
-		t.Errorf("claude ideation: expected sandbox-claude:latest; args: %v", claudeArgs)
+	if !argsContainSubstring(claudeArgs, "sandbox-agents:latest") {
+		t.Errorf("claude ideation: expected sandbox-agents:latest; args: %v", claudeArgs)
 	}
-	if !argsContainSubstring(codexArgs, "sandbox-codex:latest") {
-		t.Errorf("codex ideation: expected sandbox-codex:latest; args: %v", codexArgs)
+	if !argsContainSubstring(codexArgs, "sandbox-agents:latest") {
+		t.Errorf("codex ideation: expected sandbox-agents:latest; args: %v", codexArgs)
 	}
 
 	// Both should include --network=host.
@@ -735,7 +746,7 @@ func TestAppendInstructionsMount(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r := newRunnerForArgTest(t, tc.cfgFn(t))
-			initial := []sandbox.VolumeMount{{Host: "claude-config", Container: "/home/claude/.claude", Named: true}}
+			initial := []sandbox.VolumeMount{{Host: "claude-config", Container: "/home/agent/.claude", Named: true}}
 			result := r.appendInstructionsMount(initial, sandbox.Normalize(tc.sandbox), tc.basenames)
 
 			if tc.wantNone {
@@ -794,7 +805,7 @@ func TestAppendInstructionsMountReadOnly(t *testing.T) {
 func TestCommitStyleInvocation(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      "/home/.env",
 	})
 
@@ -829,7 +840,7 @@ func TestCommitStyleInvocation(t *testing.T) {
 	// Image appears before -p.
 	imageIdx, promptIdx := -1, -1
 	for i, a := range args {
-		if a == "sandbox-claude:latest" {
+		if a == "sandbox-agents:latest" {
 			imageIdx = i
 		}
 		if a == "-p" {
@@ -850,7 +861,7 @@ func TestCommitStyleInvocation(t *testing.T) {
 func TestTitleStyleInvocation(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 
 	model := "claude-haiku-4-5"
@@ -862,7 +873,7 @@ func TestTitleStyleInvocation(t *testing.T) {
 	// -p must appear after the image.
 	imageIdx, promptIdx := -1, -1
 	for i, a := range args {
-		if a == "sandbox-claude:latest" {
+		if a == "sandbox-agents:latest" {
 			imageIdx = i
 		}
 		if a == "-p" {
@@ -981,7 +992,7 @@ func TestContainerSpecResourceFlagsBeforeExtraFlags(t *testing.T) {
 func TestBuildBaseContainerSpecPropagatesResourceLimits(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:         "podman",
-		SandboxImage:    "sandbox-claude:latest",
+		SandboxImage:    "sandbox-agents:latest",
 		ContainerCPUs:   "1.5",
 		ContainerMemory: "2g",
 	})
@@ -1002,7 +1013,7 @@ func TestBuildBaseContainerSpecPropagatesResourceLimits(t *testing.T) {
 func TestBuildBaseContainerSpecNoResourceLimitsWhenEmpty(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 
 	spec := r.buildBaseContainerSpec("c-test", "", "claude")
@@ -1030,7 +1041,7 @@ func TestBuildBaseContainerSpecResourceLimitsFromEnvFile(t *testing.T) {
 
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envPath,
 		// ContainerCPUs and ContainerMemory intentionally left empty to test env-file fallback.
 	})
@@ -1053,7 +1064,7 @@ func TestBuildBaseContainerSpecResourceLimitsFromEnvFile(t *testing.T) {
 func TestBuildBaseContainerSpecParityWithBuildContainerArgsForSandbox(t *testing.T) {
 	r := newRunnerForArgTest(t, RunnerConfig{
 		Command:      "podman",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      "/home/.env",
 	})
 	model := "claude-opus-4-6"
@@ -1139,8 +1150,8 @@ func TestExecutorRunArgsClaudeSandbox(t *testing.T) {
 }
 
 // TestExecutorRunArgsCodexSandbox verifies that when the task sandbox is set to
-// "codex", the args forwarded to executor.RunArgs reference the sandbox-codex
-// image (derived from the base sandbox-claude image name).
+// "codex", the args forwarded to executor.RunArgs reference the sandbox-agents
+// image (derived from the base sandbox-agents image name).
 func TestExecutorRunArgsCodexSandbox(t *testing.T) {
 	repo := setupTestRepo(t)
 	mock := &MockSandboxBackend{
@@ -1149,8 +1160,8 @@ func TestExecutorRunArgsCodexSandbox(t *testing.T) {
 		},
 	}
 	s, r := setupRunnerWithMockBackend(t, []string{repo}, mock)
-	// Use a sandbox-claude image so sandboxImageForSandbox derives the codex variant.
-	r.sandboxImage = "sandbox-claude:latest"
+	// Use a sandbox-agents image so sandboxImageForSandbox derives the codex variant.
+	r.sandboxImage = "sandbox-agents:latest"
 	ctx := context.Background()
 
 	task, err := s.CreateTaskWithOptions(ctx, store.TaskCreateOptions{Prompt: "executor args codex test", Timeout: 5})
@@ -1171,10 +1182,10 @@ func TestExecutorRunArgsCodexSandbox(t *testing.T) {
 		t.Fatal("expected at least one RunArgs call")
 	}
 
-	// sandboxImageForSandbox("codex") with base image "sandbox-claude:latest" produces
-	// "sandbox-codex:latest".
-	if !argsContainSubstring(calls[0].Args, "sandbox-codex") {
-		t.Errorf("expected sandbox-codex image in args; args: %v", calls[0].Args)
+	// sandboxImageForSandbox("codex") with base image "sandbox-agents:latest" produces
+	// "sandbox-agents:latest".
+	if !argsContainSubstring(calls[0].Args, "sandbox-agents") {
+		t.Errorf("expected sandbox-agents image in args; args: %v", calls[0].Args)
 	}
 }
 

--- a/internal/runner/container_spec_test.go
+++ b/internal/runner/container_spec_test.go
@@ -321,7 +321,7 @@ func TestContainerSpecFullArgs(t *testing.T) {
 	spec := sandbox.ContainerSpec{
 		Runtime: "/opt/podman/bin/podman",
 		Name:    "wallfacer-task-abc12345",
-		Image:   "sandbox-claude:latest",
+		Image:   "sandbox-agents:latest",
 		Labels: map[string]string{
 			"wallfacer.task.id":     "abc12345-1111-2222-3333-444444444444",
 			"wallfacer.task.prompt": "fix the bug",
@@ -329,7 +329,7 @@ func TestContainerSpecFullArgs(t *testing.T) {
 		EnvFile: "/home/user/.wallfacer/.env",
 		Env:     map[string]string{"CLAUDE_CODE_MODEL": "claude-opus-4-6"},
 		Volumes: []sandbox.VolumeMount{
-			{Host: "claude-config", Container: "/home/claude/.claude", Named: true},
+			{Host: "claude-config", Container: "/home/agent/.claude", Named: true},
 			{Host: "/repos/myproject", Container: "/workspace/myproject", Options: "z"},
 			{Host: "/instructions/CLAUDE.md", Container: "/workspace/CLAUDE.md", Options: "z,ro"},
 		},
@@ -352,11 +352,11 @@ func TestContainerSpecFullArgs(t *testing.T) {
 		"--label", "wallfacer.task.prompt=fix the bug",
 		"--env-file", "/home/user/.wallfacer/.env",
 		"-e", "CLAUDE_CODE_MODEL=claude-opus-4-6",
-		"-v", "claude-config:/home/claude/.claude",
+		"-v", "claude-config:/home/agent/.claude",
 		"--mount", "type=bind,src=/repos/myproject,dst=/workspace/myproject,z",
 		"--mount", "type=bind,src=/instructions/CLAUDE.md,dst=/workspace/CLAUDE.md,z,readonly",
 		"-w", "/workspace/myproject",
-		"sandbox-claude:latest",
+		"sandbox-agents:latest",
 		"-p", "fix the bug", "--verbose", "--output-format", "stream-json",
 	}
 
@@ -420,7 +420,7 @@ func TestCacheVolumeMountsPresent(t *testing.T) {
 			found[v.Container] = true
 		}
 	}
-	for _, want := range []string{"/home/claude/.npm", "/home/claude/.cache/pip", "/home/claude/.cargo/registry", "/home/claude/.cache/go-build"} {
+	for _, want := range []string{"/home/agent/.npm", "/home/agent/.cache/pip", "/home/agent/.cargo/registry", "/home/agent/.cache/go-build"} {
 		if !found[want] {
 			t.Errorf("expected cache volume for %s", want)
 		}

--- a/internal/runner/provenance.go
+++ b/internal/runner/provenance.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
+	"strings"
 	"time"
 
 	"changkun.de/x/wallfacer/internal/envconfig"
@@ -36,8 +37,10 @@ func (r *Runner) captureExecutionEnvironment(task store.Task) store.ExecutionEnv
 	// Sandbox: record the configured sandbox for this task.
 	env.Sandbox = r.sandboxForTaskActivity(&task, activityImplementation)
 
-	// Container image: resolve using the same logic as the container runner.
-	env.ContainerImage = r.sandboxImageForSandbox(task.Sandbox)
+	// Container image: the unified sandbox-agents image is used regardless
+	// of the per-task agent type; the agent is selected at runtime via
+	// WALLFACER_AGENT inside the container.
+	env.ContainerImage = strings.TrimSpace(r.sandboxImage)
 
 	// Container digest: query the runtime for the image's content digest.
 	// Failures are non-fatal; digest is left empty when unavailable.

--- a/internal/runner/provenance_test.go
+++ b/internal/runner/provenance_test.go
@@ -19,7 +19,7 @@ func TestCaptureExecutionEnvironment_ModelFromEnvconfig(t *testing.T) {
 
 	r := NewRunner(nil, RunnerConfig{
 		Command:      "echo",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	})
 	t.Cleanup(func() { r.Shutdown() })
@@ -46,7 +46,7 @@ func TestCaptureExecutionEnvironment_InstructionsHash(t *testing.T) {
 
 	r := NewRunner(nil, RunnerConfig{
 		Command:          "echo",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instrFile,
 	})
 	t.Cleanup(func() { r.Shutdown() })
@@ -65,7 +65,7 @@ func TestCaptureExecutionEnvironment_InstructionsHash(t *testing.T) {
 func TestCaptureExecutionEnvironment_MissingInstructions(t *testing.T) {
 	r := NewRunner(nil, RunnerConfig{
 		Command:          "echo",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: "/nonexistent/path/CLAUDE.md",
 	})
 	t.Cleanup(func() { r.Shutdown() })
@@ -84,7 +84,7 @@ func TestCaptureExecutionEnvironment_ContainerDigestEmpty(t *testing.T) {
 	// Using a command that will fail for an image that doesn't exist.
 	r := NewRunner(nil, RunnerConfig{
 		Command:      "false", // always exits non-zero
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 	t.Cleanup(func() { r.Shutdown() })
 
@@ -101,15 +101,15 @@ func TestCaptureExecutionEnvironment_ContainerDigestEmpty(t *testing.T) {
 func TestCaptureExecutionEnvironment_ContainerImage(t *testing.T) {
 	r := NewRunner(nil, RunnerConfig{
 		Command:      "echo",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 	t.Cleanup(func() { r.Shutdown() })
 
 	task := store.Task{}
 	env := r.captureExecutionEnvironment(task)
 
-	if env.ContainerImage != "sandbox-claude:latest" {
-		t.Errorf("ContainerImage = %q, want %q", env.ContainerImage, "sandbox-claude:latest")
+	if env.ContainerImage != "sandbox-agents:latest" {
+		t.Errorf("ContainerImage = %q, want %q", env.ContainerImage, "sandbox-agents:latest")
 	}
 }
 
@@ -118,7 +118,7 @@ func TestCaptureExecutionEnvironment_ContainerImage(t *testing.T) {
 func TestCaptureExecutionEnvironment_Sandbox(t *testing.T) {
 	r := NewRunner(nil, RunnerConfig{
 		Command:      "echo",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 	})
 	t.Cleanup(func() { r.Shutdown() })
 
@@ -145,7 +145,7 @@ func TestCaptureExecutionEnvironment_TaskModelOverride(t *testing.T) {
 
 	r := NewRunner(nil, RunnerConfig{
 		Command:      "echo",
-		SandboxImage: "sandbox-claude:latest",
+		SandboxImage: "sandbox-agents:latest",
 		EnvFile:      envFile,
 	})
 	t.Cleanup(func() { r.Shutdown() })

--- a/internal/runner/refine.go
+++ b/internal/runner/refine.go
@@ -98,7 +98,7 @@ func (r *Runner) buildRefinementContainerSpec(containerName, taskID, prompt, mod
 	spec := sandbox.ContainerSpec{
 		Runtime: r.command,
 		Name:    containerName,
-		Image:   r.sandboxImageForSandbox(sb),
+		Image:   strings.TrimSpace(r.sandboxImage),
 	}
 
 	if taskID != "" {
@@ -112,13 +112,14 @@ func (r *Runner) buildRefinementContainerSpec(containerName, taskID, prompt, mod
 		spec.EnvFile = r.envFile
 	}
 
+	spec.Env = map[string]string{"WALLFACER_AGENT": string(sb)}
 	if model != "" {
-		spec.Env = map[string]string{"CLAUDE_CODE_MODEL": model}
+		spec.Env["CLAUDE_CODE_MODEL"] = model
 	}
 
 	spec.Volumes = append(spec.Volumes, sandbox.VolumeMount{
 		Host:      "claude-config",
-		Container: "/home/claude/.claude",
+		Container: "/home/agent/.claude",
 		Named:     true,
 	})
 	spec.Volumes = r.appendCodexAuthMount(spec.Volumes, sb)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -105,7 +105,7 @@ func newTestRunnerWithInstructions(t *testing.T, instructionsPath string) *Runne
 	t.Cleanup(func() { s.Close() })
 	r := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsPath,
 	})
 	t.Cleanup(func() { r.Shutdown() })
@@ -223,7 +223,7 @@ func TestContainerArgsSingleWorkspaceMountsCLAUDEMDInsideRepo(t *testing.T) {
 
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 		Workspaces:       []string{ws},
 	})
@@ -263,7 +263,7 @@ func TestContainerArgsMultiWorkspaceMountsCLAUDEMDAtWorkspace(t *testing.T) {
 
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 		Workspaces:       []string{ws1, ws2},
 	})
@@ -312,16 +312,16 @@ func TestContainerArgsCodexMountsHostAuthCache(t *testing.T) {
 
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 		CodexAuthPath:    codexAuthDir,
 	})
 	t.Cleanup(func() { runner.Shutdown() })
 	args := runner.buildContainerArgsForSandbox("test-container", "", "do something", "", nil, "", nil, "", "codex")
 
-	expectedMount := "type=bind,src=" + hostPath(codexAuthDir, "podman") + ",dst=/home/codex/.codex," + expectedBuildROSuffix()
+	expectedMount := "type=bind,src=" + hostPath(filepath.Join(codexAuthDir, "auth.json"), "podman") + ",dst=/home/agent/.codex/auth.json," + expectedBuildROSuffix()
 	if !containsConsecutive(args, "--mount", expectedMount) {
-		t.Fatalf("codex sandbox: expected host codex auth cache mount %q; got args: %v", expectedMount, args)
+		t.Fatalf("codex sandbox: expected host codex auth.json mount %q; got args: %v", expectedMount, args)
 	}
 }
 
@@ -339,7 +339,7 @@ func TestContainerArgsCodexUsesCodexImage(t *testing.T) {
 
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 	})
 	t.Cleanup(func() { runner.Shutdown() })
@@ -347,7 +347,7 @@ func TestContainerArgsCodexUsesCodexImage(t *testing.T) {
 
 	found := false
 	for _, a := range args {
-		if a == "sandbox-codex:latest" {
+		if a == "sandbox-agents:latest" {
 			found = true
 			break
 		}
@@ -416,7 +416,7 @@ func TestContainerArgsCLAUDEMDMountPosition(t *testing.T) {
 
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 		Workspaces:       []string{ws},
 	})
@@ -429,7 +429,7 @@ func TestContainerArgsCLAUDEMDMountPosition(t *testing.T) {
 		if strings.Contains(a, "CLAUDE.md") {
 			claudeMDIdx = i
 		}
-		if a == "sandbox-claude:latest" {
+		if a == "sandbox-agents:latest" {
 			imageIdx = i
 		}
 	}
@@ -516,7 +516,7 @@ func TestBuildContainerArgs_WorkspaceMountsAfterSnapshotUpdate(t *testing.T) {
 	// Start with ws1 only.
 	runner := NewRunner(s, RunnerConfig{
 		Command:          "podman",
-		SandboxImage:     "sandbox-claude:latest",
+		SandboxImage:     "sandbox-agents:latest",
 		InstructionsPath: instructionsFile,
 		Workspaces:       []string{ws1},
 	})

--- a/internal/sandbox/parse_test.go
+++ b/internal/sandbox/parse_test.go
@@ -13,7 +13,7 @@ func TestParseContainerListPodmanJSON(t *testing.T) {
 		{
 			"Id":      "abc123",
 			"Names":   []string{"wallfacer-myslug-12345678"},
-			"Image":   "sandbox-claude:latest",
+			"Image":   "sandbox-agents:latest",
 			"State":   "running",
 			"Status":  "Up 5 minutes",
 			"Created": 1711150800,
@@ -44,8 +44,8 @@ func TestParseContainerListPodmanJSON(t *testing.T) {
 // TestParseContainerListDockerNDJSON verifies parsing Docker's NDJSON format
 // (one JSON object per line) where Names is a bare string with a leading "/".
 func TestParseContainerListDockerNDJSON(t *testing.T) {
-	line1 := `{"Id":"def456","Names":"wallfacer-slug-aabbccdd","Image":"sandbox-claude:latest","State":"running","Status":"Up 2 minutes","Labels":{"wallfacer.task.id":"11111111-2222-3333-4444-555555555555"}}`
-	line2 := `{"Id":"ghi789","Names":"/wallfacer-other-11223344","Image":"sandbox-codex:latest","State":"exited","Status":"Exited (0) 1 minute ago","Labels":{}}`
+	line1 := `{"Id":"def456","Names":"wallfacer-slug-aabbccdd","Image":"sandbox-agents:latest","State":"running","Status":"Up 2 minutes","Labels":{"wallfacer.task.id":"11111111-2222-3333-4444-555555555555"}}`
+	line2 := `{"Id":"ghi789","Names":"/wallfacer-other-11223344","Image":"sandbox-agents:latest","State":"exited","Status":"Exited (0) 1 minute ago","Labels":{}}`
 	data := []byte(line1 + "\n" + line2 + "\n")
 
 	result, err := ParseContainerList(data)
@@ -81,7 +81,7 @@ func TestParseContainerListTaskIDFallback(t *testing.T) {
 		{
 			"Id":      "xyz999",
 			"Names":   []string{"wallfacer-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
-			"Image":   "sandbox-claude:latest",
+			"Image":   "sandbox-agents:latest",
 			"State":   "running",
 			"Status":  "Up 1 minute",
 			"Created": 1711150800,
@@ -203,7 +203,7 @@ func TestBuildCreatePreservesAllMounts(t *testing.T) {
 		Name:    "test-worker",
 		Image:   "test:latest",
 		Volumes: []VolumeMount{
-			{Host: "claude-config", Container: "/home/claude/.claude", Named: true},
+			{Host: "claude-config", Container: "/home/agent/.claude", Named: true},
 			{Host: "/host/worktree", Container: "/workspace/repo", Options: "z"},
 			{Host: "/host/instructions", Container: "/workspace/AGENTS.md", Options: "ro"},
 		},
@@ -212,7 +212,7 @@ func TestBuildCreatePreservesAllMounts(t *testing.T) {
 	args := spec.BuildCreate()
 	joined := strings.Join(args, " ")
 
-	if !strings.Contains(joined, "-v claude-config:/home/claude/.claude") {
+	if !strings.Contains(joined, "-v claude-config:/home/agent/.claude") {
 		t.Errorf("missing named volume: %s", joined)
 	}
 	if !strings.Contains(joined, "src=/host/worktree") {


### PR DESCRIPTION
## Summary

Cuts wallfacer over to the unified `sandbox-agents` image (latere-ai/images PR #2, released as v0.0.6+) and deletes the per-agent image-rewrite paths. The Claude vs. Codex sandbox type still matters at runtime — it just no longer maps to two distinct images.

**Required: ship the `latere-ai/images` `sandbox-agents` release first.** Until that GHCR image is published, `make pull-images` and the on-startup auto-pull will fail.

## Behaviour changes

- The runner injects `WALLFACER_AGENT={claude,codex}` into every sub-agent container so the unified entrypoint launches the right CLI.
- All `/home/claude/...` and `/home/codex/...` mount targets become `/home/agent/...`, including the `claude-config` named volume, the codex auth bind-mount, and the dependency-cache volumes (npm, pip, cargo, go-build).
- The codex auth mount now bind-mounts only `~/.codex/auth.json` (read-only) instead of the whole `~/.codex/` directory. Codex 0.120+ writes `config.toml` at startup, so the in-container directory must remain writable; mounting only `auth.json` keeps host state untouched. (This is the same fix shipped in latere-ai/images PR #2 for the standalone `sandbox-codex` image.)
- `wallfacer doctor` reports a single sandbox image instead of two and no longer probes `CODEX_SANDBOX_IMAGE` separately.
- `GetImageStatus`, `PullImage`, `DeleteImage` operate on the single image. The API still accepts a `sandbox` field for backward compatibility but ignores it.

## Code cuts

Deleted as dead with the unified image:

- `cli.codexImageFromClaude`
- `cli.resolveSandboxImageForExec`
- `runner.sandboxImageForSandbox`
- `runner.entrypointForSandbox`
- `handler.testCodexImage`
- `handler.fallbackCodexSandboxImage`
- The test families asserting their behaviour (`TestCodexImageFromClaude`, `TestResolveSandboxImageForExec_*`, `TestSandboxImageForTest_CodexResolution`, `TestBuildBaseContainerSpecClaudeVsCodexImageDiffers` rewritten to assert WALLFACER_AGENT injection instead of image divergence).

The `sandbox.Type` enum (`Claude`, `Codex`) is preserved unchanged — only image-name rewriting goes away. Per-activity sandbox routing (`WALLFACER_SANDBOX_IMPLEMENTATION` etc.) keeps its semantics; it now flows into `WALLFACER_AGENT` instead of choosing an image.

## Build & docs

- Default image: `ghcr.io/latere-ai/sandbox-agents:latest`.
- `Makefile`: `IMAGE`, `GHCR_IMAGE` switched to `sandbox-agents`; `CODEX_IMAGE`, `GHCR_CODEX_IMAGE` deleted; `pull-images` pulls one image.
- `CLAUDE.md`, `docs/guide/getting-started.md`, `docs/guide/configuration.md`, `docs/internals/development.md`, `docs/internals/workspaces-and-config.md`, `docs/internals/api-and-transport.md`, `docs/internals/git-worktrees.md` all document the unified image and the `WALLFACER_AGENT` dispatch contract.

## Verification

- `go test ./...` — 3714 tests pass across 46 packages.
- `make lint` — clean (golangci-lint + Biome).
- Local hand-test against the locally built `sandbox-agents:test` image earlier in this session confirmed Codex dispatch via `WALLFACER_AGENT=codex` returns a valid Claude-Code JSON envelope, and Claude dispatch honours `CLAUDE_DEFAULT_MODEL`.

## Test plan

- [ ] CI green on this branch.
- [ ] Once the next `latere-ai/images` release publishes `sandbox-agents:vX.Y.Z`, run `make build` end-to-end on a clean machine to confirm the auto-pull picks up the right tag (the existing `cli.SandboxTag` ldflag plumbing still resolves via the GitHub API or build-time embed).
- [ ] Run `make e2e-lifecycle SANDBOX=claude` and `SANDBOX=codex` against a running server to verify both dispatch paths complete a real task end-to-end.
- [ ] Run `make e2e-dependency-dag` to confirm conflict resolution / autosync still work with the new image.

## Follow-ups (not in this PR)

- Teach the worker-reuse path (`WALLFACER_TASK_WORKERS=true`) to switch `WALLFACER_AGENT` mid-life so a single long-lived worker can serve different agent types across activities. Today each worker is still pinned to one agent type at create time, even though the image now supports both.
- Tidy the UI for the single-image world (`ui/js/images.js` currently shows the entry under the legacy "Claude" header; could be relabelled "Sandbox").
