### PR TITLE
runner: kill orphaned host processes before worktree directory removal

### DIFF
--- a/internal/runner/worktree.go
+++ b/internal/runner/worktree.go
@@ -1,10 +1,16 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
 
 	"changkun.de/x/wallfacer/internal/gitutil"
 	"changkun.de/x/wallfacer/internal/logger"
@@ -137,6 +143,7 @@ func (r *Runner) cleanupWorktrees(taskID uuid.UUID, worktreePaths map[string]str
 		}
 	}
 	taskWorktreeDir := filepath.Join(r.worktreesDir, taskID.String())
+	killWorktreeProcesses(taskWorktreeDir)
 	if err := os.RemoveAll(taskWorktreeDir); err != nil && !os.IsNotExist(err) {
 		logger.Runner.Warn("remove worktree dir", "task", taskID, "error", err)
 	}
@@ -209,4 +216,61 @@ func (r *Runner) PruneUnknownWorktrees() {
 	//
 	// Stale worktree entries are cleaned up by the periodic GC
 	// (StartWorktreeGC) and by RemoveWorktree during normal task cleanup.
+}
+
+// killWorktreeProcesses sends SIGTERM (then SIGKILL after 3 s) to any host
+// processes whose working directory is inside dir. This cleans up servers and
+// watchers started during interactive Claude Code sessions before the worktree
+// directory is deleted.
+//
+// On systems without lsof, or if lsof returns an error, the function is a
+// silent no-op. The self-PID guard prevents wallfacer from killing itself.
+func killWorktreeProcesses(dir string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// lsof -a -d cwd -F pn: list only the cwd file descriptor for each
+	// process, in field format (p<pid>, n<path>).
+	out, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-F", "pn").Output()
+	if err != nil {
+		return
+	}
+
+	var pids []int
+	var curPID int
+	for _, line := range strings.Split(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(line, "p"):
+			pid, err := strconv.Atoi(strings.TrimPrefix(line, "p"))
+			if err == nil {
+				curPID = pid
+			}
+		case strings.HasPrefix(line, "n"):
+			cwdPath := strings.TrimPrefix(line, "n")
+			if strings.HasPrefix(cwdPath, dir) && curPID != 0 && curPID != os.Getpid() {
+				pids = append(pids, curPID)
+			}
+		}
+	}
+
+	if len(pids) == 0 {
+		return
+	}
+
+	logger.Runner.Info("killing orphaned host processes in worktree", "dir", dir, "pids", pids)
+
+	for _, pid := range pids {
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+	}
+
+	// Give processes 3 s to exit gracefully before force-killing.
+	time.Sleep(3 * time.Second)
+
+	for _, pid := range pids {
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Signal(syscall.SIGKILL)
+		}
+	}
 }

--- a/internal/runner/worktree_gc.go
+++ b/internal/runner/worktree_gc.go
@@ -223,6 +223,7 @@ func (r *Runner) PruneOrphanedWorktrees(ctx context.Context, orphans []uuid.UUID
 			}
 		}
 
+		killWorktreeProcesses(taskDir)
 		if err := os.RemoveAll(taskDir); err != nil && !os.IsNotExist(err) {
 			logger.Runner.Warn("worktree GC: remove task dir", "task", id, "error", err)
 			continue


### PR DESCRIPTION
## Problem

When a wallfacer session ends and the worktree is removed, any server or
watcher processes started during that session (e.g. `python app.py`,
`npm run dev`) keep running on the host. Their working directory now points
to a deleted (or re-used) path, causing the next session's edits to be
invisible to the running server.

**Concrete symptom:**
```
jinja2.exceptions.TemplateNotFound: index.html
```

The Flask process is still running from the old, deleted worktree path. It
can no longer read `templates/` because the directory is gone from disk.

**Root cause in `cleanupWorktrees()` and `PruneOrphanedWorktrees()`:**

`StopTaskWorker()` only terminates the sandbox container (Docker/containerd).
It does not affect host-level processes started during interactive Claude Code
sessions, which run directly on the host with the worktree path as their CWD.

## Fix

Add `killWorktreeProcesses(dir string)` in `internal/runner/worktree.go`,
called immediately before `os.RemoveAll()` in both:
- `cleanupWorktrees()` — normal task completion path
- `PruneOrphanedWorktrees()` — GC path

The function uses `lsof -a -d cwd -F pn` to find all host processes whose
CWD is inside the worktree directory, sends SIGTERM, waits 3 s for graceful
shutdown, then sends SIGKILL.

**Safety properties:**
- On systems without `lsof`, the function is a silent no-op
- Self-PID guard prevents wallfacer from killing itself
- Only affects processes whose CWD is *inside* the worktree being removed

## Testing

Start a dev server inside a wallfacer task worktree, complete/cancel the
task, and verify the server process is terminated automatically rather than
lingering with a stale CWD.

---
*This fix was identified from a real symptom encountered during testing of `v0.0.7-alpha.3` with `--backend host`.*