### PR TITLE
internal/cli: skip sandbox image pull in host backend mode

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -173,7 +173,13 @@ func initServer(configDir string, cfg ServerConfig, uiFS, docsFS fs.FS) *ServerC
 		logger.Main.Info("workspace instructions", "path", snapshot.InstructionsPath)
 	}
 
-	resolvedImage := ensureImage(cfg.ContainerCmd, cfg.SandboxImage)
+	// Skip image pull entirely when running in host mode: tasks run directly
+	// via the host claude/codex binary, so the sandbox container image is never
+	// used. Pulling it wastes bandwidth and time on every startup.
+	resolvedImage := cfg.SandboxImage
+	if cfg.SandboxBackend != "host" {
+		resolvedImage = ensureImage(cfg.ContainerCmd, cfg.SandboxImage)
+	}
 	codexAuthPath := ""
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		codexAuthPath = filepath.Join(home, ".codex")


### PR DESCRIPTION
## Problem

When wallfacer starts in `--backend host` mode, `server.go` still calls
`ensureImage()` unconditionally to resolve the sandbox container image.
In host mode, tasks are executed directly via the host `claude`/`codex`
binary — the sandbox image is never used — so this pull costs bandwidth
and startup time every time the server boots.

## Fix

Guard the `ensureImage` call behind a backend check:

```go
// Skip image pull entirely when running in host mode.
resolvedImage := cfg.SandboxImage
if cfg.SandboxBackend != "host" {
    resolvedImage = ensureImage(cfg.ContainerCmd, cfg.SandboxImage)
}
```

`cfg.SandboxImage` is still passed through unchanged so the value
remains available in the config struct (used for display/logging).

## Test plan
- [ ] `wallfacer run --backend host` starts without pulling the sandbox image
- [ ] `wallfacer run` (default container mode) still resolves/pulls the image as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)