### PR TITLE
internal/runner: add nil task guard and log swallowed errors

### DIFF
--- a/internal/runner/oversight.go
+++ b/internal/runner/oversight.go
@@ -240,7 +240,10 @@ func (r *Runner) buildActivityLog(ctx context.Context, taskID uuid.UUID, fromTur
 	slices.Sort(turnKeys)
 
 	// Build a turn→timestamp index from output events.
-	events, _ := r.taskStore(taskID).GetEvents(ctx, taskID)
+	events, err := r.taskStore(taskID).GetEvents(ctx, taskID)
+	if err != nil {
+		logger.Runner.Warn("oversight: GetEvents failed", "task", taskID, "error", err)
+	}
 	turnTimestamps := buildTurnTimestamps(events)
 
 	var activities []turnActivity

--- a/internal/runner/recovery.go
+++ b/internal/runner/recovery.go
@@ -43,17 +43,21 @@ func missingRecoveryWorktrees(t store.Task) []string {
 func markTaskFailedForMissingWorktrees(ctx context.Context, s *store.Store, task store.Task, from store.TaskStatus, trigger store.Trigger) {
 	message := fmt.Sprintf("task worktree missing for: %s", strings.Join(missingRecoveryWorktrees(task), ", "))
 	logger.Recovery.Warn("task worktree missing during recovery", "task", task.ID, "from", from, "error", message)
-	_ = s.ForceUpdateTaskStatus(ctx, task.ID, store.TaskStatusFailed)
-
-	_ = s.SetTaskFailureCategory(ctx, task.ID, store.FailureCategoryWorktree)
-
-	_ = s.InsertEvent(ctx, task.ID, store.EventTypeError, map[string]string{
-
+	if err := s.ForceUpdateTaskStatus(ctx, task.ID, store.TaskStatusFailed); err != nil {
+		logger.Recovery.Warn("markTaskFailed: ForceUpdateTaskStatus", "task", task.ID, "error", err)
+	}
+	if err := s.SetTaskFailureCategory(ctx, task.ID, store.FailureCategoryWorktree); err != nil {
+		logger.Recovery.Warn("markTaskFailed: SetTaskFailureCategory", "task", task.ID, "error", err)
+	}
+	if err := s.InsertEvent(ctx, task.ID, store.EventTypeError, map[string]string{
 		"error": message,
-	})
-	_ = s.InsertEvent(ctx, task.ID, store.EventTypeStateChange,
-
-		store.NewStateChangeData(from, store.TaskStatusFailed, trigger, nil))
+	}); err != nil {
+		logger.Recovery.Warn("markTaskFailed: InsertEvent error", "task", task.ID, "error", err)
+	}
+	if err := s.InsertEvent(ctx, task.ID, store.EventTypeStateChange,
+		store.NewStateChangeData(from, store.TaskStatusFailed, trigger, nil)); err != nil {
+		logger.Recovery.Warn("markTaskFailed: InsertEvent stateChange", "task", task.ID, "error", err)
+	}
 }
 
 // RecoverOrphanedTasks reconciles in_progress/committing tasks on startup by

--- a/internal/runner/title.go
+++ b/internal/runner/title.go
@@ -26,6 +26,10 @@ func (r *Runner) GenerateTitle(taskID uuid.UUID, prompt string) {
 		logger.Runner.Warn("GenerateTitle get task failed", "task", taskID, "error", err)
 		return
 	}
+	if task == nil {
+		logger.Runner.Warn("GenerateTitle: task not found", "task", taskID)
+		return
+	}
 	if task.Title != "" {
 		return
 	}


### PR DESCRIPTION
## Problems fixed

### 1. Nil pointer dereference in `title.go`

`GetTask` can return `(nil, nil)` when the task doesn't exist (store implementations
are permitted to return a nil pointer without an error). The previous code checked
`err != nil` but then immediately dereferenced `task.Title` — a potential panic if
`task` is nil.

```go
// Added nil guard:
if task == nil {
    logger.Runner.Warn("GenerateTitle: task not found", "task", taskID)
    return
}
```

### 2. Silently swallowed errors in `recovery.go`

`markTaskFailedForMissingWorktrees` discarded all store errors with `_ =`:
- `ForceUpdateTaskStatus`
- `SetTaskFailureCategory`
- Two `InsertEvent` calls

These are replaced with `Warn`-level log calls so failures are visible in
the log rather than silently dropped. The function continues best-effort
(same semantics) but now surfaces problems for debugging.

### 3. Discarded error from `GetEvents` in `oversight.go`

`events, _ := r.taskStore(taskID).GetEvents(ctx, taskID)` silently discarded
the error. Changed to capture and log it at `Warn` level; `events` is still
passed to `buildTurnTimestamps` (nil-safe) so behaviour is unchanged.

## Test plan
- [ ] Compile passes (`go build ./...`)
- [ ] `GenerateTitle` no longer panics when task is not found
- [ ] Recovery log lines appear in output when store operations fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)