### PR TITLE
internal/runner: log silently discarded errors in commit and retry paths

### DIFF
--- a/internal/runner/commit.go
+++ b/internal/runner/commit.go
@@ -76,7 +76,10 @@ func (r *Runner) commit(
 
 		"result": "Phase 1/3: Staging and committing changes...",
 	})
-	task, _ := r.taskStore(taskID).GetTask(bgCtx, taskID)
+	task, getErr := r.taskStore(taskID).GetTask(bgCtx, taskID)
+	if getErr != nil {
+		logger.Runner.Warn("autoCommit: GetTask failed", "task", taskID, "error", getErr)
+	}
 	taskPrompt := ""
 	if task != nil {
 		taskPrompt = task.Prompt
@@ -788,7 +791,10 @@ func (r *Runner) resolveConflicts(
 
 	output, rawStdout, rawStderr, err := r.runContainer(ctx, taskID, prompt, sessionID, override, "", nil, "", activityCommitMessage)
 
-	task, _ := r.taskStore(taskID).GetTask(r.shutdownCtx, taskID)
+	task, getErr := r.taskStore(taskID).GetTask(r.shutdownCtx, taskID)
+	if getErr != nil {
+		logger.Runner.Warn("resolveConflictWithContainer: GetTask failed", "task", taskID, "error", getErr)
+	}
 	turns := 0
 	if task != nil {
 		turns = task.Turns + 1

--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -119,6 +119,7 @@ func (r *Runner) tryAutoRetry(bgCtx context.Context, taskID uuid.UUID, category 
 		return false
 	}
 	if err := r.taskStore(taskID).IncrementAutoRetryCount(bgCtx, taskID, category); err != nil {
+		logger.Runner.Warn("tryAutoRetry: IncrementAutoRetryCount failed", "task", taskID, "category", category, "error", err)
 		return false
 	}
 	// Re-read to get the updated count for the event message.
@@ -803,7 +804,10 @@ func (r *Runner) SyncWorktrees(taskID uuid.UUID, sessionID string, prevStatus st
 			return
 		}
 
-		n, _ := gitutil.CommitsBehind(repoPath, worktreePath)
+		n, behindErr := gitutil.CommitsBehind(repoPath, worktreePath)
+		if behindErr != nil {
+			logger.Runner.Warn("CommitsBehind failed, skipping rebase", "task", taskID, "repo", filepath.Base(repoPath), "error", behindErr)
+		}
 		if n == 0 {
 			_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeSystem, map[string]string{
 


### PR DESCRIPTION
## Problems fixed

### 1. `commit.go` — GetTask errors silently discarded (×2)

Two call sites used `task, _ := r.taskStore(taskID).GetTask(...)`:

- **`autoCommit`** (phase 1 of the host commit pipeline): if GetTask fails,
  `taskPrompt` is empty and the commit message generator gets no context.
  The error was invisible.
- **`resolveConflictWithContainer`**: same pattern — `turns` falls back to 0
  when GetTask fails but no warning is emitted.

Both are now logged at `Warn` level via a named error variable. The nil-check
on `task` and the fallback behaviour are preserved.

### 2. `execute.go` — `IncrementAutoRetryCount` failure not logged

`tryAutoRetry` returned `false` silently when the store write failed.
In the logs it was impossible to distinguish "retry budget exhausted" from
"store error". The error is now logged at `Warn` before returning.

### 3. `execute.go` — `CommitsBehind` error silently swallowed

In `syncToDefaultBranch`, a git error from `CommitsBehind` would produce
`n=0`, silently skipping the rebase as if the repo were already up-to-date.
The error is now logged at `Warn` level, leaving an audit trail for debugging.

## Test plan
- [ ] Compile passes (`go build ./...`)
- [ ] Warn log lines appear when store/git operations fail in these paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)