### PR TITLE
internal: log silently discarded errors in config, worktree, and store

### DIFF
--- a/internal/handler/config.go
+++ b/internal/handler/config.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"changkun.de/x/wallfacer/internal/auth"
-
 	"changkun.de/x/wallfacer/internal/envconfig"
+	"changkun.de/x/wallfacer/internal/logger"
 	"changkun.de/x/wallfacer/internal/pkg/httpjson"
 	"changkun.de/x/wallfacer/internal/prompts"
 	"changkun.de/x/wallfacer/internal/sandbox"
@@ -373,7 +373,9 @@ func (h *Handler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 			if *req.Autopush {
 				v = "true"
 			}
-			_ = envconfig.Update(h.envFile, envconfig.Updates{AutoPush: &v})
+			if err := envconfig.Update(h.envFile, envconfig.Updates{AutoPush: &v}); err != nil {
+				logger.Handler.Warn("config: failed to persist autopush setting to .env", "error", err)
+			}
 		}
 	}
 	if req.IdeationExploitRatio != nil {

--- a/internal/runner/commit.go
+++ b/internal/runner/commit.go
@@ -76,7 +76,10 @@ func (r *Runner) commit(
 
 		"result": "Phase 1/3: Staging and committing changes...",
 	})
-	task, _ := r.taskStore(taskID).GetTask(bgCtx, taskID)
+	task, getErr := r.taskStore(taskID).GetTask(bgCtx, taskID)
+	if getErr != nil {
+		logger.Runner.Warn("autoCommit: GetTask failed", "task", taskID, "error", getErr)
+	}
 	taskPrompt := ""
 	if task != nil {
 		taskPrompt = task.Prompt
@@ -788,7 +791,10 @@ func (r *Runner) resolveConflicts(
 
 	output, rawStdout, rawStderr, err := r.runContainer(ctx, taskID, prompt, sessionID, override, "", nil, "", activityCommitMessage)
 
-	task, _ := r.taskStore(taskID).GetTask(r.shutdownCtx, taskID)
+	task, getErr := r.taskStore(taskID).GetTask(r.shutdownCtx, taskID)
+	if getErr != nil {
+		logger.Runner.Warn("resolveConflictWithContainer: GetTask failed", "task", taskID, "error", getErr)
+	}
 	turns := 0
 	if task != nil {
 		turns = task.Turns + 1

--- a/internal/runner/execute.go
+++ b/internal/runner/execute.go
@@ -119,6 +119,7 @@ func (r *Runner) tryAutoRetry(bgCtx context.Context, taskID uuid.UUID, category 
 		return false
 	}
 	if err := r.taskStore(taskID).IncrementAutoRetryCount(bgCtx, taskID, category); err != nil {
+		logger.Runner.Warn("tryAutoRetry: IncrementAutoRetryCount failed", "task", taskID, "category", category, "error", err)
 		return false
 	}
 	// Re-read to get the updated count for the event message.
@@ -803,7 +804,10 @@ func (r *Runner) SyncWorktrees(taskID uuid.UUID, sessionID string, prevStatus st
 			return
 		}
 
-		n, _ := gitutil.CommitsBehind(repoPath, worktreePath)
+		n, behindErr := gitutil.CommitsBehind(repoPath, worktreePath)
+		if behindErr != nil {
+			logger.Runner.Warn("CommitsBehind failed, skipping rebase", "task", taskID, "repo", filepath.Base(repoPath), "error", behindErr)
+		}
 		if n == 0 {
 			_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeSystem, map[string]string{
 

--- a/internal/runner/worktree.go
+++ b/internal/runner/worktree.go
@@ -66,7 +66,10 @@ func (r *Runner) ensureTaskWorktrees(taskID uuid.UUID, existing map[string]strin
 			}
 			logger.Runner.Warn("worktree directory exists but is not a valid git repo, removing",
 				"workspace", ws, "path", worktreePath)
-			_ = os.RemoveAll(worktreePath)
+			if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+				logger.Runner.Warn("failed to remove broken worktree directory",
+					"workspace", ws, "path", worktreePath, "error", removeErr)
+			}
 
 		}
 

--- a/internal/store/tasks_update.go
+++ b/internal/store/tasks_update.go
@@ -69,7 +69,10 @@ func (s *Store) UpdateTaskStatus(_ context.Context, id uuid.UUID, status TaskSta
 // notified of the done transition. GetOversight reads directly from disk and
 // does not acquire s.mu, so it is safe to call here.
 func (s *Store) buildAndSaveSummary(task Task) {
-	oversight, _ := s.GetOversight(task.ID)
+	oversight, oversightErr := s.GetOversight(task.ID)
+	if oversightErr != nil {
+		logger.Store.Warn("buildAndSaveSummary: GetOversight failed", "task", task.ID, "error", oversightErr)
+	}
 	phaseCount := 0
 	if oversight != nil {
 		phaseCount = len(oversight.Phases)


### PR DESCRIPTION
## Problems fixed

### 1. `handler/config.go` — autopush .env write failure invisible

When a user toggles auto-push in the UI, the in-memory setting is updated via
`h.SetAutopush(...)` and then `envconfig.Update` is called to persist it to the
`.env` file. The `envconfig.Update` error was discarded with `_ =`.

If the write fails (permissions, disk full, concurrent write), the in-memory
toggle is updated but the change is lost on server restart. The user sees no
indication that the setting wasn't saved. The error is now logged at `Warn`
level so the failure is visible in logs.

### 2. `runner/worktree.go` — broken worktree removal failure invisible

When a worktree directory exists but is not a valid git repo (e.g. `.git` link
was deleted by a container), the code calls `os.RemoveAll` and discards the
error. If the removal fails, the subsequent `MkdirAll` / `CreateWorktree` will
also fail with a less informative error ("file exists" or similar). The removal
error is now logged at `Warn` level before falling through.

### 3. `store/tasks_update.go` — oversight error discarded in summary builder

`buildAndSaveSummary` calls `GetOversight` to compute `phaseCount` for the
`summary.json` file written when a task completes. The error was discarded with
`_, _`. When `GetOversight` fails (JSON corruption, disk error), `oversight` is
nil, `phaseCount` is silently set to 0, and the summary file is written with
incomplete data. The error is now logged at `Warn` level.

## Test plan
- [ ] Compile passes (`go build ./...`)
- [ ] Toggling auto-push when `.env` is read-only produces a Warn log line
- [ ] Broken worktree removal failure produces a Warn log line
- [ ] Corrupt oversight.json produces a Warn log line during task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)