### PR TITLE
feat(glass): luminance lift so glass reads as frost, not a scrim

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -27,7 +27,7 @@
         "@xterm/xterm": "^6.0.0",
         "codemirror": "^6.0.1",
         "highlight.js": "^11.11.1",
-        "latere-ui": "github:latere-ai/latere-ui#v1.21.0",
+        "latere-ui": "github:latere-ai/latere-ui#v1.22.0",
         "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^9.2.0",
         "mermaid": "^11.14.0",
@@ -822,7 +822,7 @@
 
     "langium": ["langium@4.2.3", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.3", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, ""],
 
-    "latere-ui": ["latere-ui@github:latere-ai/latere-ui#d67352e", { "peerDependencies": { "pinia": "^2.2.0 || ^3.0.0", "vue": "^3.5.0" } }, "latere-ai-latere-ui-d67352e", "sha512-SvNo+FgoWTD+9RICc1LY8twNkIhrDISJvl/QGCNbt+xoCxqhWHVR2vzxbzm8FcervtvHWUGs/evuSbc/kqPUXQ=="],
+    "latere-ui": ["latere-ui@github:latere-ai/latere-ui#e0460da", { "peerDependencies": { "pinia": "^2.2.0 || ^3.0.0", "vue": "^3.5.0" } }, "latere-ai-latere-ui-e0460da", "sha512-6ht9UuLMWfEJHQmXI10S4FK5Zjxj0eTvRxsh5ILBd9/2Xn6Vp9sxkjs3I2zoXnyjM1iz+LBmUq3b+gCId5LzCw=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, ""],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@xterm/xterm": "^6.0.0",
     "codemirror": "^6.0.1",
     "highlight.js": "^11.11.1",
-    "latere-ui": "github:latere-ai/latere-ui#v1.21.0",
+    "latere-ui": "github:latere-ai/latere-ui#v1.22.0",
     "markdown-it": "^14.1.0",
     "markdown-it-anchor": "^9.2.0",
     "mermaid": "^11.14.0",

--- a/frontend/src/styles/app/navbar-auth.css
+++ b/frontend/src/styles/app/navbar-auth.css
@@ -26,8 +26,8 @@
     background: var(--glass-bg-thin);
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-pill);
-    backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate));
-    -webkit-backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate));
+    backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
+    -webkit-backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
     box-shadow:
         var(--glass-edge-top),
         0 8px 32px rgba(0, 0, 0, 0.10),

--- a/frontend/src/styles/app/responsive-motion.css
+++ b/frontend/src/styles/app/responsive-motion.css
@@ -57,8 +57,8 @@
            capsule over page content, so it takes the near-opaque overlay fill
            from the shared glass ladder (occludes rather than reveals). */
         background: var(--glass-bg-thick);
-        backdrop-filter: blur(var(--glass-blur-thick)) saturate(var(--glass-saturate));
-        -webkit-backdrop-filter: blur(var(--glass-blur-thick)) saturate(var(--glass-saturate));
+        backdrop-filter: blur(var(--glass-blur-thick)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
+        -webkit-backdrop-filter: blur(var(--glass-blur-thick)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
         border: 1px solid var(--glass-border);
         border-radius: var(--radius-lg);
         box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);

--- a/frontend/src/styles/header/content-header.css
+++ b/frontend/src/styles/header/content-header.css
@@ -13,8 +13,8 @@
      wallfacer's tuned --glass-bg fill for legibility over the busy board.
      Chrome only — the board content scrolls beneath, never frosted. */
   background: var(--glass-bg);
-  -webkit-backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate));
-  backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
+  backdrop-filter: blur(var(--glass-blur-thin)) saturate(var(--glass-saturate)) brightness(var(--glass-brightness, 1));
   box-shadow: var(--glass-edge-top);
 }
 


### PR DESCRIPTION
## Problem

Dark-mode glass chrome darkened the content behind it into a **dark scrim** instead of the bright frost Apple's Liquid Glass reads as. As the landing hero scrolls under the nav capsule, the heading dims rather than lifting *through* the glass.

Two compounding causes, both now understood:
- The v2 material had no luminance lift — a 0.58-alpha dark fill over dark content just darkens.
- The Chromium-only SVG lensing runtime never closed the gap: Safari cannot do `feDisplacementMap` in `backdrop-filter` at all, and the runtime skips sub-16px-radius elements anyway.

## Fix

The real fix is a plain `brightness()` folded into the backdrop chain — supported in **every** engine (WebKit + Chromium), no SVG lensing required.

- **latere-ui v1.22.0** (released separately): new `--glass-brightness` token (dark 1.5, light no-op), baked into every `.lu-glass*` tier, lighter dark on-surface fills, brighter dark rim. a11y fallbacks reset the lift to 1.
- **This PR (wallfacer):** repin to v1.22.0 and append `brightness(var(--glass-brightness))` to the three surfaces that **hand-roll** their backdrop chain instead of using the classes (nav capsule, mobile nav sheet, content header). The lift is a filter *function*, so it cannot flow through the `--glass-*` value tokens — each hand-rolled chain needs the explicit edit on both the standard and `-webkit-` property.

## Verification

Rendered the real `.site-header` capsule over the actual landing hero in **WebKit** (Safari-equivalent) — the heading now lifts through the glass as frost with a visible specular rim, versus the reported dark-scrim screenshot. latere-ui ships 226 passing tests including new coverage for the lift and its a11y reset. Frontend `vue-tsc` + `vite-ssg` build passes.

## Global rollout (other consumers)

latere-ui v1.22.0 is the shared primitive, but **6 other repos also hand-roll** the chain and each needs the same one-line edit (a repin alone would make them a more-transparent dark layer with no lift). Checklist tracked separately: agents, agon, latere-ai, lectio, sandbox, lux.