### PR TITLE
Fix topos native-run commit gap (#17) and add release attestation (#16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ name: Release
 # build, produces the CLI binaries, builds and pushes the wallfacerd image,
 # deploys the kustomize deploy/prod/ overlay to the shared `latere` namespace,
 # smokes the live surface, and only then publishes the GitHub release carrying
-# the binaries.
+# the binaries plus their supply-chain attestation (SHA256 checksums, an SPDX
+# SBOM, and keyless cosign signatures over both).
 #
 # Vendored, not the central latere-ai/ci pipeline: this repo lives under a
 # personal account and GitHub cannot call an org-private reusable workflow
@@ -168,6 +169,13 @@ jobs:
   release:
     needs: [binary, deploy]
     runs-on: ubuntu-latest
+    # id-token: write mints the OIDC token cosign exchanges for a short-lived
+    # Fulcio signing certificate (keyless signing — no long-lived key stored in
+    # the repo). Job-level permissions replace the workflow default, so
+    # contents: write is repeated here to keep release-asset upload working.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/download-artifact@v8
@@ -180,6 +188,41 @@ jobs:
         with:
           name: release-evidence
           path: evidence
+      - name: Generate SHA256 checksums
+        working-directory: dist
+        # One manifest over every published binary. Signing this file (below)
+        # transitively attests each binary, since a verified checksum binds the
+        # bytes. Users verify with: sha256sum -c SHA256SUMS
+        run: sha256sum wallfacer-* | tee SHA256SUMS
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          # Scan the checked-out source tree (Go modules, frontend deps) rather
+          # than the opaque binaries, so the SBOM enumerates real dependencies.
+          path: .
+          format: spdx-json
+          output-file: dist/wallfacer.spdx.json
+          # This job publishes the release itself, so let the create step attach
+          # the SBOM alongside the other assets instead of the action doing it.
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign checksums and SBOM (keyless)
+        working-directory: dist
+        env:
+          COSIGN_YES: 'true'
+        # Sigstore bundles carry the signature, signing certificate, and Rekor
+        # transparency-log proof in one file. Verify with:
+        #   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+        #     --certificate-identity-regexp '^https://github.com/changkun/wallfacer/' \
+        #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+        #     SHA256SUMS
+        run: |
+          set -euo pipefail
+          for f in SHA256SUMS wallfacer.spdx.json; do
+            cosign sign-blob --bundle "${f}.cosign.bundle" "$f"
+          done
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -206,6 +249,8 @@ jobs:
           # shipped before the release published.
           printf '\n\n' >> notes.md
           cat evidence/release-evidence.md >> notes.md
+          # dist/ now also holds SHA256SUMS, the SPDX SBOM, and the two cosign
+          # bundles, so the glob attaches the attestation with the binaries.
           gh release create "$TAG" $prerelease \
             --title "Wallfacer $TAG" \
             --notes-file notes.md \

--- a/internal/runner/agentic.go
+++ b/internal/runner/agentic.go
@@ -142,9 +142,10 @@ func (r *Runner) runAgenticFlow(bgCtx context.Context, taskID uuid.UUID, task st
 // is the path a task resolves to when its harness is Topos (the native default,
 // once harness.Default() is flipped; until then only an explicit topos pin
 // reaches here). Like the agentic-flow path it produces a final text + lineage
-// and walks the state machine, but it does not yet make a durable git commit or
-// run verification — commit/verify parity with the subprocess harnesses is
-// tracked in the topos-native-harness spec.
+// and walks the state machine; driveToposRun then runs the real commit pipeline
+// so the worktree edits land as a durable git commit. Verification (the test
+// step) parity with the subprocess harnesses is tracked in the
+// topos-native-harness spec.
 func (r *Runner) runNativeTopos(bgCtx context.Context, taskID uuid.UUID, task store.Task, prompt, worktree string) {
 	// worktree is the task's set-up worktree (the real repo) so the agent's tools
 	// edit actual files; an empty worktree falls back to the topos temp-dir sandbox.
@@ -171,8 +172,11 @@ func firstWorktreePath(worktreePaths map[string]string) string {
 // the JSON-marshalled lineage graph, then walks the task through the same
 // in_progress -> waiting -> committing -> done state machine the flow-engine and
 // ideation branches use (the state machine forbids a direct in_progress -> done
-// transition). runFn performs the actual topos run, wired with the supplied
-// non-blocking observer. The caller sets statusSet=true before invoking this.
+// transition). In the committing phase it runs the real commit pipeline
+// (r.Commit) when the run has a worktree, so a native run's edits land as a
+// durable git commit rather than reaching done uncommitted. runFn performs the
+// actual topos run, wired with the supplied non-blocking observer. The caller
+// sets statusSet=true before invoking this.
 func (r *Runner) driveToposRun(bgCtx context.Context, taskID uuid.UUID, task store.Task, runFn func(ctx context.Context, onEvent func(agentgraph.TraceEvent)) (agentgraph.Result, error)) {
 	timeout := time.Duration(task.Timeout) * time.Minute
 	if timeout <= 0 {
@@ -245,6 +249,32 @@ func (r *Runner) driveToposRun(bgCtx context.Context, taskID uuid.UUID, task sto
 	_ = r.taskStore(taskID).UpdateTaskStatus(bgCtx, taskID, store.TaskStatusCommitting)
 	_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeStateChange,
 		store.NewStateChangeData(store.TaskStatusWaiting, store.TaskStatusCommitting, store.TriggerSystem, nil))
+
+	// Run the real commit pipeline so a native topos run produces a durable git
+	// commit of the agent's worktree edits (stage -> commit -> rebase -> merge
+	// into the default branch), matching the subprocess implement path's
+	// auto-submit. Without this the run edits the worktree but reaches done with
+	// the work uncommitted. r.Commit re-fetches the task, so it sees the worktree
+	// paths execute.go persisted after this snapshot was taken.
+	//
+	// The commit is gated on a worktree being present. The native single-agent
+	// path (runNativeTopos) runs in the task's worktree and commits here; the
+	// multi-agent agentic path (runAgenticFlow) is dispatched before worktree
+	// setup and runs in a topos temp sandbox with no worktree, so there is
+	// nothing in the repo to commit and it walks straight to done as before.
+	// Threading a worktree through the agentic path is deferred (tracked on #17).
+	if cur, gErr := r.taskStore(taskID).GetTask(bgCtx, taskID); gErr == nil && cur != nil && len(cur.WorktreePaths) > 0 {
+		if err := r.Commit(taskID, ""); err != nil {
+			logger.Runner.Error("topos run commit", "task", taskID, "error", err)
+			_ = r.taskStore(taskID).SetTaskFailureCategory(bgCtx, taskID, classifyFailure(err, false, ""))
+			_ = r.taskStore(taskID).UpdateTaskStatus(bgCtx, taskID, store.TaskStatusFailed)
+			_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeError, map[string]string{"error": err.Error()})
+			_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeStateChange,
+				store.NewStateChangeData(store.TaskStatusCommitting, store.TaskStatusFailed, store.TriggerSystem, nil))
+			return
+		}
+	}
+
 	_ = r.taskStore(taskID).UpdateTaskStatus(bgCtx, taskID, store.TaskStatusDone)
 	_ = r.taskStore(taskID).InsertEvent(bgCtx, taskID, store.EventTypeStateChange,
 		store.NewStateChangeData(store.TaskStatusCommitting, store.TaskStatusDone, store.TriggerSystem, nil))

--- a/internal/runner/agentic_test.go
+++ b/internal/runner/agentic_test.go
@@ -208,3 +208,54 @@ func TestRun_AgenticFlowReachesDoneWithLineage(t *testing.T) {
 		t.Fatalf("lineage edges = %+v, want one next edge", lin.Edges)
 	}
 }
+
+// TestRun_NativeToposHarnessCommitsWorktreeEdits is the regression guard for the
+// bug where the topos native path walked committing -> done without ever making
+// a git commit: the agent edited the worktree, but the state machine reported
+// success with the work uncommitted. With a real workspace repo and a prompt that
+// writes a file, the run must now produce a durable commit merged onto the repo's
+// default branch (the full commit pipeline stage -> commit -> rebase -> merge ->
+// cleanup, same as the subprocess implement path's auto-submit).
+func TestRun_NativeToposHarnessCommitsWorktreeEdits(t *testing.T) {
+	repo := setupTestRepo(t)
+	s, r := setupTestRunner(t, []string{repo})
+	enableCommitMessageGeneration(t, r)
+	initialHash := gitRun(t, repo, "rev-parse", "HEAD")
+
+	ctx := context.Background()
+	// The fake model runs the prompt as a shell command in the worktree, so a
+	// redirect writes a file the agent "created" into the real repo checkout.
+	task, err := s.CreateTaskWithOptions(ctx, store.TaskCreateOptions{
+		Prompt:  "topos change > topos-marker.txt",
+		Timeout: 5,
+		Sandbox: harness.Topos,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := s.UpdateTaskStatus(ctx, task.ID, store.TaskStatusInProgress); err != nil {
+		t.Fatalf("UpdateTaskStatus: %v", err)
+	}
+
+	r.Run(task.ID, task.Prompt, "", false)
+	r.WaitBackground()
+	s.WaitCompaction()
+
+	updated, _ := s.GetTask(ctx, task.ID)
+	if updated.Status != store.TaskStatusDone {
+		t.Fatalf("status = %q, want done", updated.Status)
+	}
+
+	// The full pipeline merges the worktree branch onto the default branch, so a
+	// new commit must exist on the repo itself (the worktree is cleaned up).
+	finalHash := gitRun(t, repo, "rev-parse", "HEAD")
+	if finalHash == initialHash {
+		t.Fatal("expected a new commit on the default branch, but HEAD is unchanged (topos run did not commit)")
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, "topos-marker.txt")); statErr != nil {
+		t.Fatalf("agent's file was not committed onto the default branch: %v", statErr)
+	}
+	if len(updated.CommitHashes) == 0 {
+		t.Error("no commit hashes were recorded on the task")
+	}
+}


### PR DESCRIPTION
Addresses the two open issues.

## #17 — Topos native run never commits
`driveToposRun` walked `waiting -> committing -> done` via the state machine but never ran the commit pipeline, so a native topos run edited its worktree and reached `done` with the work **uncommitted**. The committing phase now calls `r.Commit`, producing a durable git commit (stage -> commit -> rebase -> merge into the default branch) matching the subprocess implement path's auto-submit.

- Gated on a worktree being present, so the multi-agent agentic path (dispatched before worktree setup, running in a topos temp sandbox) still walks straight to `done` unchanged.
- **Deferred:** threading a worktree through the agentic path so it commits too. `RunFlowWithModel` takes no worktree and `runAgenticFlow` is dispatched before worktree setup, so that is a larger change; left tracked on #17.

**Test:** `TestRun_NativeToposHarnessCommitsWorktreeEdits` drives a native topos run against a real repo and asserts a new commit landed on the default branch. Verified it fails without the fix ("HEAD is unchanged") and passes with it. Existing empty-worktree topos tests exercise the skip branch and stay green.

## #16 — Release supply-chain attestation
The `release` job now also produces and attaches:
- `SHA256SUMS` over every published binary,
- an SPDX SBOM of the source tree (`anchore/sbom-action`),
- keyless cosign signatures (sigstore bundles) over the checksums and the SBOM.

`id-token: write` lets cosign exchange the GitHub OIDC token for a short-lived Fulcio cert — no signing key stored in the repo. Verification commands are documented inline in the workflow.

## Checks
- `go vet`, `gofmt`, `golangci-lint` (2.11.3, 0 issues) on the runner package
- full `internal/runner` suite green (193s)
- `actionlint` clean on `release.yml`; third-party action inputs confirmed against `anchore/sbom-action`