### PR TITLE
docs: fix structural link paths and drop removed AGENTS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ you only want to *use* Wallfacer, start with the [User Manual](docs/guide/usage.
   the codebase: architecture, package layout, API routes, task lifecycle, and
   storage model. Read it first. The references below are written for maintainers,
   not end users.
-- **[AGENTS.md](AGENTS.md)** (symlinked as `CLAUDE.md`) holds the project's
+- **[CLAUDE.md](CLAUDE.md)** holds the project's
   commit and workflow conventions for both humans and coding agents.
 - **[Specs & Roadmap](specs/README.md)** tracks design work in progress and the
   dependency graph between tracks.
@@ -70,4 +70,4 @@ so this is a local-macOS ergonomics issue, not a correctness one. Locally, pass
   [`docs/guide/`](docs/guide/); internals in [`docs/internals/`](docs/internals/).
 
 The commit and workflow conventions every change must follow are in
-[AGENTS.md](AGENTS.md) (symlinked as `CLAUDE.md`).
+[CLAUDE.md](CLAUDE.md).

--- a/specs/cloud/latere-integration/coordination-plane.md
+++ b/specs/cloud/latere-integration/coordination-plane.md
@@ -130,7 +130,7 @@ a layered model (default: local credential proof using the user's own git creds;
 fallback: org-admin-registered repos + membership; upgrade: per-user GitHub OAuth),
 with the **org boundary as the security perimeter** (cross-tenant access is
 structurally impossible). The full data model, storage tiers, and verification
-flow are in [repo-identity](latere-integration/coordination-plane/repo-identity.md).
+flow are in [repo-identity](coordination-plane/repo-identity.md).
 
 ### Multiple replicas
 
@@ -143,7 +143,7 @@ single-replica fallback for local dev. Valkey is a cache and holds only ephemera
 coordination state; **durable, authoritative** data (spec comments, the projection
 long-tail rollups) lives in **Postgres** (`latere-pg`, the `wallfacer` database now
 provisioned alongside the cache secret). The full design is in
-[connection](latere-integration/coordination-plane/connection-and-presence/connection.md);
+[connection](coordination-plane/connection-and-presence/connection.md);
 the durable-tier provisioning is an open decision (see Open questions).
 
 ## Capabilities riding the plane

--- a/specs/local/first-run-onboarding.md
+++ b/specs/local/first-run-onboarding.md
@@ -2,7 +2,7 @@
 title: First-Run Onboarding & Agent-Graph Discoverability
 status: vague
 depends_on:
-  - ../../agents/specs/architecture/agent-sdk-mesh-foundation.md
+  - ../../../agents/specs/architecture/agent-sdk-mesh-foundation.md
 affects:
   - frontend/src/views/
   - frontend/src/components/
@@ -24,7 +24,7 @@ dispatched_task_id: null
 A brand-new user can understand what Wallfacer is and get to a first useful action
 without prior knowledge — and can understand the merged **agent graph** (Agents +
 Flows unified per
-[agent-sdk-mesh-foundation](../../agents/specs/architecture/agent-sdk-mesh-foundation.md))
+[agent-sdk-mesh-foundation](../../../agents/specs/architecture/agent-sdk-mesh-foundation.md))
 rather than facing two disjoint, jargon-heavy surfaces.
 
 ## Why this exists (and why it is deferred)

--- a/specs/local/topos-runtime-integration.md
+++ b/specs/local/topos-runtime-integration.md
@@ -2,7 +2,7 @@
 title: Topos Runtime Integration (Embed the Agent-Graph Runtime)
 status: complete
 depends_on:
-  - ../../agents/specs/architecture/agent-sdk-mesh-foundation.md
+  - ../../../agents/specs/architecture/agent-sdk-mesh-foundation.md
 affects:
   - go.mod
   - internal/runner/
@@ -135,6 +135,6 @@ editing the graph edits the underlying agents/flows YAML registries.
 ## Notes
 
 Builds on the embeddable SDK foundation
-([agent-sdk-mesh-foundation](../../agents/specs/architecture/agent-sdk-mesh-foundation.md)).
+([agent-sdk-mesh-foundation](../../../agents/specs/architecture/agent-sdk-mesh-foundation.md)).
 The runtime is consumed only through the root `topos` package; the engine subpackages
 stay an implementation detail behind the import guard.


### PR DESCRIPTION
Doc-maintenance loop, iteration 3: broken relative link sweep in `wallfacer`.

Fixes 8 broken links where the path structure was wrong (target exists, link is malformed) plus the removed `AGENTS.md` reference:

- **`CONTRIBUTING.md`**: `AGENTS.md` was removed (commit `ac1810be`); `CLAUDE.md` is now the real canonical file, not a symlink. Repoint the two working-agreement references and drop the stale "symlinked as CLAUDE.md" note.
- **`specs/local/{first-run-onboarding,topos-runtime-integration}.md`**: cross-repo `depends_on` and links to `agents/` used `../../` (stops at the wallfacer root) instead of `../../../` (workspace root). Fixed frontmatter + body.
- **`specs/cloud/latere-integration/coordination-plane.md`**: two sibling links duplicated the `latere-integration/` path segment.

**Left untouched (needs author decision), ~22 links:**
- Live specs referencing now-archived design docs (`harness-abstraction`, `host-default`, `authentication`, `storage-backends`, `oauth-token-setup`, `spec-comments`). Repointing an active spec into `.archive/` vs un-archiving the foundation is a design call, not a mechanical fix.
- Links inside `status: stale` specs (`topos-remote-executor`, `cella-runtime`, `github-integration`, `oauth-token-store`, `pull-request`) — these are already flagged for rework.
- `frontend/scripts/ui-shots/README.md` `images/foo.png` is documented example syntax, not a real link.

Verified: every repointed target resolves from its file's real checkout location.